### PR TITLE
Ps wip 1.1.4

### DIFF
--- a/src/duHast/UI/Objects/WPF/Xaml/XamlLoader.py
+++ b/src/duHast/UI/Objects/WPF/Xaml/XamlLoader.py
@@ -56,7 +56,7 @@ class XamlLoader(object):
         :rtype: System.Windows.UIElement
         """
         # Read the XAML file
-        with open(xaml_path, 'r', encoding='utf-8-sig') as file:
+        with open(xaml_path, "r") as file:
             xaml_content = file.read()
 
         # Parse the XAML content

--- a/src/duHast/UI/Objects/WPF/Xaml/XamlLoader.py
+++ b/src/duHast/UI/Objects/WPF/Xaml/XamlLoader.py
@@ -32,7 +32,7 @@ https://markheath.net/post/wpf-and-mvvm-in-ironpython
 #
 #
 
-
+import codecs
 from System.Windows.Markup import XamlReader
 
 
@@ -56,7 +56,7 @@ class XamlLoader(object):
         :rtype: System.Windows.UIElement
         """
         # Read the XAML file
-        with open(xaml_path, "r") as file:
+        with codecs.open(xaml_path, "r", encoding="utf-8-sig") as file:
             xaml_content = file.read()
 
         # Parse the XAML content

--- a/src/duHast/UI/files_select/ViewModel.py
+++ b/src/duHast/UI/files_select/ViewModel.py
@@ -1,5 +1,5 @@
-from duHast.UI.Objects.ViewModelBase import ViewModelBase
-from duHast.UI.Objects.CommandBase import CommandBase
+from duHast.UI.Objects.WPF.ViewModels.ViewModelBase import ViewModelBase
+from duHast.UI.Objects.WPF.Commands.CommandBase import CommandBase
 from duHast.UI.Objects.file_item import MyFileItem
 from duHast.UI.file_list import get_revit_files_for_processing
 

--- a/src/duHast/UI/files_select/files_select_ui.py
+++ b/src/duHast/UI/files_select/files_select_ui.py
@@ -20,7 +20,7 @@ sys.path.insert(0, ROOT_REPO_DIRECTORY)
 from duHast.UI import file_list as fl
 from duHast.UI.Objects.file_select_settings import FileSelectionSettings
 from duHast.UI.file_list import get_revit_files_for_processing
-from duHast.UI.Objects.XamlLoader import XamlLoader
+from duHast.UI.Objects.WPF.Xaml.XamlLoader import XamlLoader
 from duHast.UI import workloader as wl
 
 from duHast.Utilities.files_io import file_exist


### PR DESCRIPTION
Hi Jan,

that files_select_ui function has references to the old location of the XamlLoader and others. This should hopefully fix that

Also, I don't think the below is python 2 compatible so updated to something that is

```
with open(xaml_path, "r", encoding="utf-8-sig") as file:
            xaml_content = file.read()
```

This is off a fresh pull of 1.1.4 this morning btw. Is this the same thing as I had yesterday?