### PR TITLE
Rewrite pyRevit extension docs from the code, and fix the broken buttons found doing it

### DIFF
--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Levels.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Levels.pushbutton/script.py
@@ -12,7 +12,7 @@ output = script.get_output()
 doc= revit.doc
 
 
-# import ceiling exporter
+# import level exporter
 from data.Collectors.levels import levels_export_entry
 
 # run the exporter 

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Rooms.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Rooms.pushbutton/script.py
@@ -11,7 +11,7 @@ output = script.get_output()
 doc= revit.doc
 
 
-# import ceiling exporter
+# import room exporter
 from data.Collectors.rooms import rooms_export_entry
 
 # run the exporter 

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Sheets.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Sheets.pushbutton/script.py
@@ -12,7 +12,7 @@ doc= revit.doc
 
 
 
-# import ceiling exporter
+# import sheet exporter
 from data.Collectors.sheets import sheets_export_entry
 
 # run the exporter 

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Spaces.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Spaces.pushbutton/script.py
@@ -1,4 +1,4 @@
-print("Oh, hi there! This is the rooms collector script running...")
+print("Oh, hi there! This is the spaces collector script running...")
 
 import sys
 import os
@@ -11,7 +11,7 @@ output = script.get_output()
 doc= revit.doc
 
 
-# import ceiling exporter
+# import space exporter
 from data.Collectors.spaces import spaces_export_entry
 
 # run the exporter 

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Families.panel/ChangeFamilyCategory.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Families.panel/ChangeFamilyCategory.pushbutton/script.py
@@ -1,17 +1,20 @@
 """
-An extension applying a hack to force an update to a family when loaded into a project file
+An extension changing the category of the family open in the family editor.
 
-The hack is:
-- create a new family type
-- save the family
-- delete the new family type
-- save the family again
+Any subcategories are preserved: they are recreated under the new category and elements are
+re-assigned to them.
 
+Note:
+
+- This runs on the open family document only, not on families loaded in a project.
+- The family is not saved by this script.
 
 Usage:
 
+- Open the family in the family editor.
 - Run the script.
 
+    - Select the new category.
     - The progress will be displayed in the output window.
 
 """

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/View Templates.panel/Modify.pulldown/bundle.yaml
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/View Templates.panel/Modify.pulldown/bundle.yaml
@@ -4,8 +4,6 @@ layout:
   - Delete Filters
   - ----------
   - Apply Graphic Overrides
-  - ----------
-  - Add And Apply Filter Overrides Views
 
 # bundle tooltip
 tooltip: Anything relating to view template settings

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Walls.panel/FacadeOpeningToRoom.pushbutton/script.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/Walls.panel/FacadeOpeningToRoom.pushbutton/script.py
@@ -1,4 +1,17 @@
-print("hello world")
+"""
+An extension reporting external wall and window opening areas per room to a csv file.
+
+Usage:
+
+- Run the script.
+- Select the rooms to report on.
+- Select a location to save the csv file to.
+
+Note:
+
+- The external wall types, window opening families and phase of interest are configured in
+  the rooms.rooms_facade_openings module.
+"""
 
 # pyrevit stuff
 from pyrevit import revit, script, forms
@@ -9,7 +22,7 @@ output = script.get_output()
 doc = revit.doc
 
 
-# import grids and bubbles from library
+# import facade openings reporting from library
 from rooms.rooms_facade_openings import rooms_facade_openings_entry
 
 # report facade opening per rooms

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/bundle.yaml
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/bundle.yaml
@@ -4,7 +4,6 @@ layout:
   - Grids And Levels
   - View Templates
   - Views
-  - Colour Fill Schemes
   - Purge Unused
   - Warnings
   - Families

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/bulk_load.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/bulk_load.py
@@ -64,10 +64,11 @@ def get_families(directory):
     # filter out family backup files ( ending in .00??.rfa )
     families_in_directory = remove_backup_revit_files_from_list(families_in_directory)
 
-    # filter out families which occur more than once
+    # filter out families which occur more than once, keeping the first one found
     for path in families_in_directory:
         file_name = os.path.basename(path)
         if file_name not in file_names:
+            file_names.append(file_name)
             filtered_families.append(path)
 
     return filtered_families

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/exportCatalogueFile/export_catalogue_file.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/exportCatalogueFile/export_catalogue_file.py
@@ -23,7 +23,10 @@ import os
 
 from duHast.Utilities.Objects.result import Result
 from duHast.Utilities.files_io import get_file_name_without_ext
-from duHast.Revit.Family.family_types_catalogue import export_catalogue_file
+# aliased: this module exposes an entry point of the same name below
+from duHast.Revit.Family.family_types_catalogue import (
+    export_catalogue_file as export_family_types_catalogue_file,
+)
 
 
 def export_catalogue_file(doc, output, forms):
@@ -71,7 +74,7 @@ def export_catalogue_file(doc, output, forms):
     file_name = get_file_name_without_ext(doc.Title)
     output_file_name = os.path.join(family_out_folder_path, "{}.txt".format(file_name))
 
-    export_result = export_catalogue_file(
+    export_result = export_family_types_catalogue_file(
         doc=doc,
         file_path = output_file_name, 
         filters = None, 

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/reload/reloader_v2.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/families/reload/reloader_v2.py
@@ -45,22 +45,26 @@ DEBUG = False
 DLL_LIST = [UTILITY,WPF_CUSTOM_CONTROLS,FAMILY_RELOADER_UI]
 
 
-def reload_families(doc, families, forms):
+def reload_families(doc, families, forms, load_all_family_types=False):
     """
     Reloads families in the Revit model.
-    
+
     :param doc: Current Revit model document.
     :type doc: Autodesk.Revit.DB.Document
     :param families: List of families to reload.
     :type families: list of Family objects
     :param forms: pyRevit forms module.
     :type forms: pyRevit forms module
+    :param load_all_family_types: If True, family types introduced by the library file are kept
+        ( the UI's "Import All Types On Reload" ). If False, only types already in the document
+        are updated and any new type is deleted again after the reload.
+    :type load_all_family_types: bool
     :return: Result class instance.
         - `result` (bool): True if families were reloaded successfully, otherwise False.
         - `message` (str): details about the reloading process.
     :rtype: :class:`.Result`
     """
-    
+
     return_value = Result()
 
     fam_counter = 0
@@ -73,9 +77,11 @@ def reload_families(doc, families, forms):
                 # reload_family(doc, family, family_file_path):
                 revit_family = doc.GetElement(ElementId(Int64(fam.RevitElementId)))
                 reload_result = reload_family(
-                    doc=doc, 
-                    family=revit_family, 
-                    family_file_path=fam.FamilyFilePath
+                    doc=doc,
+                    family=revit_family,
+                    family_file_path=fam.FamilyFilePath,
+                    # keeping new types is the inverse of deleting them
+                    delete_new_types=not load_all_family_types,
                 )
                 return_value.update(reload_result)
 
@@ -172,10 +178,24 @@ def reloaded_families_entry(doc, output, forms):
         
         
         # reload the families
-        print("Will {} reload families").format(families_reload.FamiliesToReload.Count)
-        
+        print("Will reload {} families".format(families_reload.FamiliesToReload.Count))
+
+        # honour the reload mode picked in the UI: "Import All Types On Reload" keeps any
+        # type the library file introduces, otherwise only existing types are updated
+        load_all_family_types = families_reload.LoadAllFamilyTypesOnReload
+        print(
+            "Reload mode: {}".format(
+                "import all types"
+                if load_all_family_types
+                else "reload existing types only"
+            )
+        )
+
         reloader_result = reload_families(
-            doc=doc, families=families_reload.FamiliesToReload, forms=forms
+            doc=doc,
+            families=families_reload.FamiliesToReload,
+            forms=forms,
+            load_all_family_types=load_all_family_types,
         )
         return_value.update(reloader_result)
         print(reloader_result.message)

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_and_ceilings.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_and_ceilings.py
@@ -62,8 +62,11 @@ def room_name_builder_ui(doc, element):
 
 def ceilings_to_rooms_entry(doc, output, forms):
     """
-    Compares reports from different libraries.
-    Reports need to be created by report_families_in_library function.
+    Creates a ceiling matching the boundary of each user selected room.
+
+    The ceiling type is resolved from the room's ceiling finish parameter, falling back to a
+    default type. Ceiling elevation and the phase the ceiling is created in are set by the
+    module level constants.
 
     :param doc: Current Revit model document.
     :type doc: Autodesk.Revit.DB.Document

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_and_walls.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_and_walls.py
@@ -64,8 +64,11 @@ def room_name_builder_ui(doc, element):
 
 def walls_to_rooms_entry(doc, output, forms):
     """
-    Compares reports from different libraries.
-    Reports need to be created by report_families_in_library function.
+    Writes the room number into a user selected parameter on the walls bounding each user
+    selected room.
+
+    Where a wall bounds more than one room, the room with the longest shared boundary segment
+    wins.
 
     :param doc: Current Revit model document.
     :type doc: Autodesk.Revit.DB.Document

--- a/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_facade_openings.py
+++ b/Samples/pyRevit/Extensions/duHast-2025.extension/duHast.tab/lib/rooms/rooms_facade_openings.py
@@ -53,7 +53,7 @@ from rooms.family_utils import get_window_families_by_host_id, window_area_insta
 
 from Autodesk.Revit.DB import BuiltInParameter, Element, ElementId, SharedParameterElement
 
-DEBUG = True
+DEBUG = False
 
 OPENING_FAMILY_NAMEs = ["WDW_Generic_Window Opening", "WDW_Generic_Window Opening_Instance"]
 

--- a/Samples/pyRevit/about.md
+++ b/Samples/pyRevit/about.md
@@ -1,0 +1,47 @@
+# About
+
+**Panel:** About | **Menu:** About
+
+<img src="Extensions/duHast-2025.extension/duHast.tab/About.panel/About.pulldown/Icon.png" width="40" alt="button icon">
+
+Two reference links. Neither reads from nor modifies the Revit model — each opens a page in
+your default web browser and nothing else.
+
+The menu lists **License** first, then a separator, then **Icon8**.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/About.panel/About.pulldown/License.pushbutton/Icon.png" width="24" alt="License icon"> License
+
+Opens the extension's licence on GitHub:
+
+`https://github.com/jchristel/SampleCodeRevitBatchProcessor?tab=License-1-ov-file#readme`
+
+The project is released under the **BSD licence**, © Jan Christel. The same licence text
+appears at the top of every source file in the extension.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/About.panel/About.pulldown/Icon8.pushbutton/Icon.png" width="24" alt="Icon8 icon"> Icon8
+
+Opens `https://icons8.com` — the source of the icons used throughout the extension.
+
+This button exists to **carry the attribution** that the Icons8 free licence requires. The
+attribution snippet itself is kept alongside the panel, in
+`Extensions/duHast-2025.extension/duHast.tab/About.panel/LinkIcon8.txt`:
+
+```html
+<a target="_blank" href="https://icons8.com/icon/111452/edit">Edit</a> icon by <a target="_blank" href="https://icons8.com">Icons8</a>
+```
+
+If you redistribute the extension, or reuse its icons elsewhere, that attribution needs to
+travel with them.
+
+---
+
+## Notes
+
+- Both buttons need an internet connection and a configured default browser. They open a
+  browser window outside Revit; Revit itself is unaffected.
+- Neither button opens a document, reads a parameter, or starts a transaction — they are safe
+  to run at any time, including with no document open.

--- a/Samples/pyRevit/ceilings_by_rooms.md
+++ b/Samples/pyRevit/ceilings_by_rooms.md
@@ -1,26 +1,60 @@
-# Ceilings By Rooms
+# Ceilings By Room
 
-**Panel:** Ceilings | **Button:** Ceilings By Rooms
+**Panel:** Ceilings | **Button:** Ceilings By Room
 
-Automatically generates ceiling elements for every room in the current Revit model, using each room's boundary as the ceiling boundary.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Ceilings.panel/CeilingsByRooms.pushbutton/Icon.png" width="40" alt="button icon">
+
+Creates a ceiling matching the boundary of each selected room.
 
 ## What it does
 
-- Reads all rooms in the active model.
-- For each room, creates a ceiling element at the level of the room, matching the room's boundary polygon.
-- Uses a configurable ceiling type and height offset.
+1. Lists every room in the model and asks you to select the rooms to model ceilings for.
+   List entries are shown as `number-name_phase_level`.
+2. For each selected room, in a cancellable progress bar:
+   - resolves the ceiling type to use (see below);
+   - takes the room's boundary at the **finish** face and converts it to closed curve loops;
+   - creates a ceiling on the room's level from those loops.
+
+## How the ceiling type is chosen
+
+1. The room's **`Ceiling Finish`** parameter is read.
+2. Its value is matched against the type mark of the ceiling types in the model.
+3. If there is no value, or no type matches it, the tool falls back to a default type — which
+   is whichever ceiling type happens to be **second** in the collector. This is arbitrary,
+   so check the result when the fallback is used; the type actually used is reported per room
+   in the output window.
+
+## Hard-coded values
+
+Two values are fixed in
+`Extensions/duHast-2025.extension/duHast.tab/lib/rooms/ceilings_create.py` and are not
+exposed in the UI:
+
+| Constant | Purpose | Current value |
+|---|---|---|
+| `PHASE_NAME` | Phase the ceilings are created in | `"Project Scope"` |
+| (elevation argument) | Height offset from the room's level | `2700` |
+
+The parameter the ceiling type code is read from is also fixed:
+`ROOM_CEILING_TYPE_PARAMETER_NAME = "Ceiling Finish"`.
+
+Edit these to suit the project before first use.
 
 ## When to use this
 
-Use this button at the start of a ceiling design phase when you need a base set of ceilings to match the room layout, saving you from drawing each ceiling boundary manually.
+Use it at the start of a ceiling design phase to get a base set of ceilings matching the room
+layout, rather than tracing each boundary by hand.
 
 ## Requirements
 
-- Rooms must have valid boundaries (closed perimeters) for Revit to calculate the ceiling shape correctly.
-- At least one ceiling type must exist in the project before running the tool.
+- Rooms must be placed and bounded so Revit returns closed boundary loops.
+- At least one ceiling type must exist in the project.
+- A phase named as per `PHASE_NAME` must exist, otherwise the ceiling is created without a
+  phase set.
 
 ## Notes
 
-- The tool creates ceilings at a default height; adjust individual ceiling heights afterwards if required.
-- Rooms without valid boundaries are skipped and reported in the pyRevit output window.
-- Run after the room layout is finalised to avoid having to regenerate ceilings after room boundary changes.
+- Rooms whose boundary cannot be converted to a closed loop are reported and skipped.
+- All ceilings are created at the same offset; adjust individual heights afterwards.
+- Run after the room layout is settled — the ceilings are not associative, so later room
+  boundary changes will not update them.

--- a/Samples/pyRevit/cloud_guids.md
+++ b/Samples/pyRevit/cloud_guids.md
@@ -1,20 +1,46 @@
-# Cloud GUIDs
+# GUIDS
 
-**Panel:** Cloud | **Button:** GUIDs
+**Panel:** Cloud | **Button:** GUIDS
 
-Retrieves the Autodesk cloud GUIDs associated with the current Revit model and displays them in the pyRevit output window.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Cloud.panel/GUIDS.pushbutton/Icon.png" width="40" alt="button icon">
+
+Collects the Autodesk cloud identifiers for the current model **and every Revit link in it**,
+prints them to the output window, and saves them as a CSV.
 
 ## What it does
 
-- Reads the cloud project GUID and model GUID from the open Revit document.
-- Displays both values in the pyRevit output window so they can be copied.
+1. Reads the Revit version and the cloud project GUID, model GUID, file size and file name
+   for the **active document**.
+2. Walks all Revit link instances in the model and reads the same values for each linked
+   document. File size for links is fetched from the cloud by model GUID.
+3. Prints one comma-separated row per model:
+
+   ```
+   version, project guid, file guid, file size, file name
+   ```
+
+4. Opens a save dialog and writes all rows to a CSV file.
+
+A link whose cloud data cannot be read is reported in the output window and skipped; the run
+continues with the remaining links.
 
 ## When to use this
 
-Use this button when you need to reference the current model in a **Revit Batch Processor** task file that targets cloud-hosted models. The GUIDs returned here are the exact identifiers required by the batch processor to open the model from Autodesk Construction Cloud or BIM 360.
+Use this when building a **Revit Batch Processor** task file that targets cloud models. The
+CSV it produces contains exactly the identifiers the batch processor needs, for the host
+model and its links in one pass — which is what makes it worth running on a federated model
+rather than reading GUIDs one file at a time.
+
+## Requirements
+
+- The active document must be hosted on Autodesk Construction Cloud or BIM 360. Local files
+  and local central files have no cloud GUIDs.
+- Cloud access is needed for the link file sizes to resolve.
 
 ## Notes
 
-- This tool only works when the active document is hosted on Autodesk Construction Cloud or BIM 360 (a cloud workshared model).
-- Local models and locally-hosted central files do not have cloud GUIDs; the tool will report nothing or an error for those models.
-- Copy the GUIDs from the output window and paste them into the relevant Revit Batch Processor configuration file.
+- The CSV is written **without a header row** — the header shown above is printed to the
+  output window only. Add it manually if your downstream process expects one.
+- Cancelling the save dialog abandons the data; the values remain visible in the output
+  window and can be copied from there.
+- Links that are unloaded, or whose document cannot be opened, contribute no row.

--- a/Samples/pyRevit/data_collectors.md
+++ b/Samples/pyRevit/data_collectors.md
@@ -2,74 +2,102 @@
 
 **Panel:** Data | **Menu:** Collectors
 
-Tools that extract element data from the current Revit model and export it to structured files for use in reporting, analysis, or external workflows.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Icon.png" width="40" alt="button icon">
+
+Eight tools that extract element data from Revit models and write it to **JSON** files for
+reporting, analysis or external workflows.
+
+## How they work
+
+All eight share the same shape:
+
+1. **Pick the models** — a document picker lists the active document and every loaded Revit
+   link, with multi-select. Data is collected from each chosen model in turn.
+2. **Save per model** — one save dialog per selected document, titled with that document's
+   name. Cancelling one save skips that model and continues with the next.
+3. Output is **JSON only**, wrapped with model metadata and a data type key, with the elapsed
+   time reported in the output window.
+
+**Exception:** the **Sheets** collector has no document picker. It runs on the active
+document only and asks for a single output file.
 
 ---
 
-## Rooms
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Rooms.pushbutton/Icon.png" width="24" alt="Rooms icon"> Rooms
 
-Exports room data from the current Revit model.
+Room data from the selected models.
 
-**Exported data includes:** Room name, number, department, level, area, and all available room parameters.
-
-Output is saved to a CSV or JSON file you specify. Use the exported data to populate spreadsheets, feed into room scheduling tools, or compare against an external Schedule of Accommodation.
-
----
-
-## Sheets
-
-Exports sheet data from the current Revit model.
-
-**Exported data includes:** Sheet number, sheet name, revision data, view names placed on the sheet, and all available sheet parameters.
-
-Use the exported data to build a document register or cross-reference with exported PDF/DWG filenames.
+Use the exported data to populate spreadsheets, feed room scheduling tools, or compare
+against an external Schedule of Accommodation.
 
 ---
 
-## Ceilings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Spaces.pushbutton/Icon.png" width="24" alt="Spaces icon"> Spaces
 
-Exports ceiling data from the current Revit model.
-
-**Exported data includes:** Ceiling type, level, area, room association, and all available ceiling parameters.
-
-Use the exported data for ceiling finish schedules or quantity take-offs.
+MEP space data from the selected models. The space equivalent of the Rooms collector.
 
 ---
 
-## Levels
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Sheets.pushbutton/Icon.png" width="24" alt="Sheets icon"> Sheets
 
-Exports level data from the current Revit model.
+Sheet data from the **active document only**.
 
-**Exported data includes:** Level name, elevation, and associated parameters.
-
-Use the exported data to verify level setup against a project brief or to populate external tools.
+Use it to build a document register or cross-reference against exported PDF/DWG filenames.
 
 ---
 
-## Floors
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Ceilings.pushbutton/Icon.png" width="24" alt="Ceilings icon"> Ceilings
 
-Exports floor data from the current Revit model.
-
-**Exported data includes:** Floor type, level, offset from level, area, design set/option membership, phasing, and all available floor instance and type parameters.
-
-Use the exported data for floor finish schedules, quantity take-offs, or to cross-reference floor layouts against room data.
+Ceiling data from the selected models. Use it for ceiling finish schedules or quantity
+take-offs.
 
 ---
 
-## Items
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Floors.pushbutton/Icon.png" width="24" alt="Floors icon"> Floors
 
-Exports placed family instance data (furniture, equipment, and similar items) from the current Revit model.
+Floor data from the selected models, including design set/option membership and phasing.
+Use it for floor finish schedules, take-offs, or to cross-reference floor layouts against
+room data.
 
-**Exported data includes:** Family type, instance parameters, level, offset from level derived from solid geometry, placement location (x/y/z in mm), facing direction (rotation matrix), room associations across all project phases, design set/option membership, and phasing.
+---
 
-By default the following categories are collected: Furniture, Furniture Systems, Mechanical Equipment, Electrical Equipment, Electrical Fixtures, Plumbing Fixtures, Specialty Equipment, and Generic Model.
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Doors.pushbutton/Icon.png" width="24" alt="Doors icon"> Doors
 
-Use the exported data for FF&E schedules, room content reports, or to verify item placement against a room data sheet.
+Door data from the selected models. Use it for door schedules and for checking door-to-room
+relationships across linked architectural models.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Levels.pushbutton/Icon.png" width="24" alt="Levels icon"> Levels
+
+Level data from the selected models. Use it to verify level setup against a project brief or
+to populate external tools.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Items.pushbutton/Icon.png" width="24" alt="Items icon"> Items
+
+Placed family instance data — furniture, equipment and similar.
+
+**Exported data includes:** family type, instance parameters, level, offset from level
+derived from solid geometry, placement location (x/y/z in mm), facing direction as a rotation
+matrix, room associations across all project phases, design set/option membership, and
+phasing.
+
+Collected categories: Furniture, Furniture Systems, Mechanical Equipment, Electrical
+Equipment, Electrical Fixtures, Plumbing Fixtures, Specialty Equipment, Generic Model.
+
+Use it for FF&E schedules, room content reports, or to verify item placement against a room
+data sheet.
 
 ---
 
 ## Notes
 
-- All collectors write to a destination file you choose via a save dialog; ensure the destination folder exists and is writable.
-- Export files are intended as point-in-time snapshots; re-run the collector to refresh the data after model changes.
-- Exported data can be used as input for Revit Batch Processor workflows that process multiple models.
+- Being able to collect from **linked models** is the main reason to use these over a Revit
+  schedule export: one run over a federated model captures every discipline.
+- Only instances with a point location are captured by the Items collector; line-based
+  placements are skipped.
+- Exports are point-in-time snapshots — re-run after model changes.
+- The JSON output is the input format for downstream duHast data processing and for Revit
+  Batch Processor workflows that process many models.

--- a/Samples/pyRevit/export_compare.md
+++ b/Samples/pyRevit/export_compare.md
@@ -2,6 +2,8 @@
 
 **Panel:** Export | **Button:** Compare
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/Compare.pushbutton/Icon.png" width="40" alt="button icon">
+
 Compares the sheets listed in a Revit schedule against the PDF files in a folder, and
 reports which sheets have no matching file and which have more than one.
 

--- a/Samples/pyRevit/export_docmanager.md
+++ b/Samples/pyRevit/export_docmanager.md
@@ -1,43 +1,65 @@
-# Document Manager
+# docManager
 
-**Panel:** Export | **Menu:** DocManager
+**Panel:** Export | **Menu:** docManager
 
-Integration with the Document Manager system for managing document numbering, metadata, and export workflows at a project level.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/docManager.pulldown/Icon.png" width="40" alt="button icon">
 
----
-
-## DocManager
-
-Opens the main Document Manager interface, which reads sheet data from the current Revit project and provides document-level management tools.
-
-- Lists all sheets with their current document numbers and metadata.
-- Allows bulk updates to document numbering based on configured rules.
-- Integrates with the document numbering settings defined in **Settings** (see below).
+Integration between Revit and the Document Manager system: it reads sheets and revisions from
+the model and synchronises them to a Document Manager database.
 
 ---
 
-## Settings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/docManager.pulldown/Settings.pushbutton/Icon.png" width="24" alt="Settings icon"> Settings
 
-Opens the [DocManagerSettingsUI](../../VS/duHastUI/DocManagerSettingsUI/docs/01_main_ui.md) configuration window.
+Configures how document numbers are built, and stores that configuration **in the model**.
 
-- Select the CSV database file that contains the project's document register.
-- Build document numbering rules by combining sheet properties (sheet number, revision, discipline code, etc.) with prefixes, suffixes, and separators.
-- Rules can be exported to or imported from a JSON file for reuse across projects.
-- Click **Save To Project** to store the configuration in the Revit project file.
+- Opens the [DocManagerSettingsUI](../../VS/duHastUI/DocManagerSettingsUI/docs/01_main_ui.md)
+  window.
+- Select the **CSV database file** holding the project's document register.
+- Build the document numbering rule by selecting and ordering sheet properties — sheet number,
+  revision, discipline code, custom sheet parameters — with prefixes, suffixes and separators.
+- Rules can be exported to and imported from JSON for reuse across projects.
+- **Save** commits the configuration and closes.
 
-**Run Settings first** on any project before using the main DocManager tool.
+Settings are written to a **extensible schema in the Revit model** as a JSON string, so they
+travel with the file — which is why this must be run **once per model** before DocManager
+itself will start.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/docManager.pulldown/DocManager.pushbutton/Icon.png" width="24" alt="DocManager icon"> DocManager
+
+Opens the main [Document Manager Revit integration](../../VS/duHastApplications/duHastNet.DocManager/duHastNet.DocManager.Revit/docs/01_main_ui.md)
+window.
+
+Before the window opens, the tool reads from the model:
+
+- the sheet data, and
+- the **revision data** on those sheets.
+
+The window then shows two panels, switched with a navigation toggle:
+
+- **Sheets** — lists sheets with their generated document numbers and metadata, and lets you
+  import new sheets into the Document Manager database.
+- **Revisions** — records revision history against the database entries.
+
+The header strip shows the connected database path and the connection status.
+
+**If the settings schema is missing**, the tool exits with a message telling you to run
+Settings first.
 
 ---
 
-## POC (Proof of Concept)
+## Requirements
 
-A lightweight demonstration of the Document Manager integration. Shows how document numbers are generated from the current settings without writing any data to the model.
-
-**Use when:** You want to preview the effect of a numbering rule configuration before committing it to the project.
-
----
+- **Settings** must have been run on this model.
+- The CSV database file must be reachable from the workstation — its path is stored in the
+  model settings, so it must be valid for everyone who uses the tool.
+- The extension's `bin` folder must be present; the windows are .NET UIs loaded from there.
 
 ## Notes
 
-- Document numbering settings are stored per-project in the Revit model.
-- The CSV database file path is also stored in the project settings and must be accessible from all workstations that use the tool.
+- Document numbering settings are per-model. A new model needs its own Settings run, or an
+  imported rule JSON.
+- Changing the numbering rule changes the document numbers generated for every sheet — review
+  the Sheets panel before importing into the database.

--- a/Samples/pyRevit/export_pdf_dwg.md
+++ b/Samples/pyRevit/export_pdf_dwg.md
@@ -1,12 +1,14 @@
-# Export PDF and DWG
+# PDF and DWG
 
 **Panel:** Export | **Button:** PDF and DWG / Settings (split button)
+
+<img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/PDF_DWG.splitbutton/Icon.png" width="40" alt="button icon">
 
 Batch-export sheets from the current Revit project to PDF and/or DWG files, following a configured naming standard.
 
 ---
 
-## PDF and DWG (main button)
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/PDF_DWG.splitbutton/PDF_DWG.pushbutton/Icon.png" width="24" alt="PDF and DWG icon"> PDF and DWG (main button)
 
 Runs the sheet export for all sheets you have selected, producing PDF and DWG output files in the configured destination folder.
 
@@ -14,18 +16,25 @@ Runs the sheet export for all sheets you have selected, producing PDF and DWG ou
 - You choose which sheets to export by ticking them individually, selecting a saved **Print Set**, or filtering by a Revit **Schedule**.
 - Preview columns show the generated PDF and DWG filenames before you commit.
 - A three-way switch lets you export **PDF only**, **DWG only**, or **both**.
+- The **export directory** is set in this window, not in Settings.
 - Click **Export** to produce the files and close the window.
+
+Any print sets you create or edit in the selection window are **written back to the model**
+before the export runs.
+
+**Run Settings first.** If no export settings are stored in the model this button exits with
+*"Cant find any settings for this file. Please run the settings add-in first."*
 
 ---
 
-## Settings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/PDF_DWG.splitbutton/Settings.pushbutton/Icon.png" width="24" alt="Settings icon"> Settings
 
 Configures the naming rules used to generate PDF and DWG filenames.
 
 - Opens the [PDFDWGExporterUI](../../VS/duHastUI/PDFDWGExporterUI/docs/01_main_ui.md) settings window.
-- You select which Revit sheet properties (sheet number, name, revision, etc.) to include in the filename, and set a prefix, suffix, and separator for each component.
-- Settings are saved to the project so they persist between sessions.
-- DWG-specific: choose an export scheme to control which DWG version and layer standards are applied.
+- You select which Revit sheet properties (sheet number, name, revision, etc.) to include in the filename, and set a prefix, suffix, and separator for each component. Any parameter present on sheets in this model can be used.
+- Settings are stored in an **extensible schema in the model** — separate JSON strings for the PDF rule, the DWG rule and the DWG export scheme name — so they travel with the file.
+- DWG-specific: choose an export scheme to control which DWG version and layer standards are applied. The list offered comes from the **predefined DWG export setups in the model**.
 
 **Run Settings before your first export** to ensure filenames match your project's naming convention.
 
@@ -34,4 +43,5 @@ Configures the naming rules used to generate PDF and DWG filenames.
 ## Notes
 
 - Print sets created in the selection window are saved to the project and can be reused on subsequent exports.
-- DWG export uses the scheme configured in Settings; make sure a compatible DWG export scheme exists in the project.
+- DWG export uses the scheme configured in Settings; create the DWG export setup in Revit first, otherwise there is nothing to choose.
+- Both buttons load .NET UI assemblies from the extension's `bin` folder at run time. If that folder is missing or incomplete, the button fails immediately with a message about the bin directory.

--- a/Samples/pyRevit/families_at_the_library.md
+++ b/Samples/pyRevit/families_at_the_library.md
@@ -2,6 +2,8 @@
 
 **Panel:** Families | **Button:** At The Library
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/AtTheLibrary.pushbutton/Icon.png" width="40" alt="button icon">
+
 Opens the **AtTheLibrary** WPF application — an interactive library browser that lets you view, filter, load, and edit families from a Schedule of Accommodation (SoA) data source without leaving Revit.
 
 ## What it does
@@ -21,4 +23,5 @@ Use this button when you need to browse a family library, check what is already 
 ## Notes
 
 - The SoA CSV file path is configured within the AtTheLibrary window (browse or type the path, then click Load Data).
+- The window is a .NET UI loaded from the extension's `bin` folder at run time. If that folder is missing or incomplete the button fails immediately with a message about the bin directory.
 - See the [AtTheLibrary user guide](../../VS/duHastRevitApplications/AtTheLibrary/docs/01_main_ui.md) for full documentation of the interface.

--- a/Samples/pyRevit/families_catalogue_files.md
+++ b/Samples/pyRevit/families_catalogue_files.md
@@ -2,6 +2,8 @@
 
 **Panel:** Families | **Menu:** Catalogue Files
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/CatalogueFiles.pulldown/Icon.png" width="40" alt="button icon">
+
 Tools for creating, cleaning, and configuring type catalogue files (`.txt`) for Revit
 families.
 
@@ -9,7 +11,7 @@ families.
 
 ---
 
-## Export File
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/CatalogueFiles.pulldown/ExportCatalogueFile.pushbutton/Icon.png" width="24" alt="Export File icon"> Export File
 
 Exports the type data of the open family to a type catalogue file.
 
@@ -22,7 +24,7 @@ file so users can choose which types to load.
 
 ---
 
-## Clean Catalogue File
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/CatalogueFiles.pulldown/DeleteParametersFromCatalogueFile.pushbutton/Icon.png" width="24" alt="Clean Catalogue File icon"> Clean Catalogue File
 
 Cleans an existing catalogue file by removing parameters that should not appear there.
 
@@ -48,7 +50,7 @@ when loading the family.
 
 ---
 
-## Default Catalogue File Type
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/CatalogueFiles.pulldown/DefaultCatalogueFileType.pushbutton/Icon.png" width="24" alt="Default Catalogue File Type icon"> Default Catalogue File Type
 
 > **Warning — this tool deletes family types.** It does not configure a pre-selected type in
 > a catalogue file. Read the steps below before running it, and work on a copy of the family

--- a/Samples/pyRevit/families_change_category.md
+++ b/Samples/pyRevit/families_change_category.md
@@ -2,6 +2,8 @@
 
 **Panel:** Families | **Button:** Change Category
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/ChangeFamilyCategory.pushbutton/Icon.png" width="40" alt="button icon">
+
 Changes the Revit category of the family currently open in the Family Editor, preserving its
 subcategories.
 

--- a/Samples/pyRevit/families_force_update.md
+++ b/Samples/pyRevit/families_force_update.md
@@ -2,23 +2,39 @@
 
 **Panel:** Families | **Button:** Force Update
 
-Forces Revit to recognise and apply changes to a family that it has already loaded, bypassing the normal "family is up to date" cache.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/ForceUpdate.pushbutton/Icon.png" width="40" alt="button icon">
+
+Forces Revit to treat the open family as modified, so that projects using it will offer to
+reload it.
 
 ## What it does
 
-1. Opens the selected family in the family editor.
-2. Creates a temporary new family type.
-3. Saves the family.
-4. Deletes the temporary type.
-5. Saves the family again.
+Operating on the family currently open in the Family Editor:
 
-This double-save with a type change tricks Revit into treating the family as modified, which causes it to prompt for reload when the family is next encountered in a project.
+1. Creates a temporary new family type.
+2. **Saves the family.**
+3. Deletes the temporary type.
+4. **Saves the family again.**
+
+The type change between the two saves is what makes Revit register the family as changed.
 
 ## When to use this
 
-Use this button when you have edited a family file on disk but Revit is not detecting the change and refusing to reload it — typically because the file timestamp or internal checksum has not changed in a way Revit recognises.
+Use this when a family file on disk has been altered — typically overwritten by a copy from
+elsewhere — but Revit does not recognise it as different and will not offer to reload it into
+a project.
+
+## Requirements
+
+- **The family must be open in the Family Editor and be the active document.** If it is not,
+  the tool reports *"This is not a family document."* and exits. It does not operate on a
+  family selected in the project browser.
 
 ## Notes
 
-- The family must be open in Revit (or you must select it from the project browser) before running this tool.
-- The temporary type is created and deleted automatically; no manual cleanup is required.
+- Unlike **Change Category**, this tool **writes to disk** — it saves the family twice, over
+  the file it was opened from. There is no prompt and no backup beyond Revit's own.
+- The temporary type is created and removed automatically; no cleanup is needed.
+- If either save fails the tool aborts and reports it, which can leave the temporary type in
+  place. Check the family's type list before saving it yourself.
+- Progress is reported in the output window.

--- a/Samples/pyRevit/families_io.md
+++ b/Samples/pyRevit/families_io.md
@@ -1,45 +1,73 @@
-# Family IO — Bulk Load and Save
+# Family IO — Load and Save
 
 **Panel:** Families | **Menu:** IO
 
-Tools to load families into the project in bulk or save families from the project back to disk.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/IO.pulldown/Icon.png" width="40" alt="button icon">
+
+Tools to load families into the project in bulk, or save loaded families back out to disk.
 
 ---
 
-## Load Them All
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/IO.pulldown/BulkLoad.pushbutton/Icon.png" width="24" alt="Load Them All icon"> Load Them All
 
-Loads every `.rfa` file found in a selected directory (and its subdirectories) into the current Revit project in a single operation.
+Loads `.rfa` files from a directory into the current project.
 
-- A folder picker lets you choose the source directory.
-- Warnings and errors that would normally interrupt a manual load are suppressed.
-- Families that are already loaded with the same name are skipped.
+**Workflow:**
 
-**Use when:** You want to populate a project with a large set of families from a library in one step.
+1. Pick the source folder. The tool searches it **and all subfolders**.
+2. Revit backup files (`*.0001.rfa` and similar) are filtered out.
+3. A list of the files found is shown — **select the families to load**. This is a
+   multi-select list, so despite the button name you are not obliged to load everything.
+4. The selected families are loaded with a progress bar.
+
+**Failure handling:** loading runs with rollback enabled for both warnings and errors. A
+family that raises either is **rolled back** — it is not loaded — and the message is printed
+to the output window. This is what happens when a family of the same name is already loaded.
+So the effective behaviour is "already-loaded families are left alone", but the reason is a
+rollback you will see reported, not a silent skip.
+
+**Use when:** Populating a project from a library folder in one pass.
 
 ---
 
-## Save Out
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/IO.pulldown/SaveOut.pushbutton/Icon.png" width="24" alt="Save Out icon"> Save Out
 
-Saves selected families from the current project to a chosen directory on disk.
+Saves families from the current project to a folder.
 
-- A UI lets you pick which loaded families to export.
-- Files are written as `.rfa` files.
-- Existing files in the destination folder are overwritten.
+**Workflow:**
+
+1. Select the families to export from a list. Only families where Revit reports the family as
+   editable are offered — in-place and system families are not.
+2. Pick the destination folder.
+
+Files are written as `.rfa` directly into that folder, and **existing files are overwritten**.
 
 ---
 
-## Save Out Advanced
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/IO.pulldown/SaveOutAdvanced.pushbutton/Icon.png" width="24" alt="Save Out Advanced icon"> Save Out Advanced
 
-An extended version of **Save Out** with additional organisation options.
+The same as **Save Out**, with a switch dialog after the folder pick offering two options:
 
-- **Organise by category:** Creates subdirectories named after Revit family categories and places each `.rfa` in the matching subdirectory.
-- **Overwrite existing files:** Controls whether existing files at the destination are replaced.
+| Switch | Effect when on |
+|---|---|
+| Save out to a single directory | All families go into the chosen folder |
+| Overwrite existing families | Existing `.rfa` files at the destination are replaced |
 
-**Use when:** You want to export families to a structured library layout organised by category.
+Turning **Save out to a single directory** off is what produces a category-organised library:
+subfolders named after each family's Revit category are created under the chosen folder and
+each family is written into the matching one.
+
+With **Overwrite existing families** off, a family whose file already exists at the
+destination is skipped.
+
+**Use when:** Building or refreshing a structured library.
 
 ---
 
 ## Notes
 
-- Ensure the destination folder exists and you have write permissions before saving.
-- **Save Out Advanced** with category organisation is the recommended approach when building or refreshing a library.
+- Each family is opened and saved in its own operation, so one failure does not abort the
+  batch — failures are reported per family in the output window.
+- Ensure the destination folder exists and is writable before starting.
+- **Save Out Advanced** with category subfolders is the better choice for library work; plain
+  **Save Out** always uses a single folder and always overwrites.

--- a/Samples/pyRevit/families_reload.md
+++ b/Samples/pyRevit/families_reload.md
@@ -1,24 +1,57 @@
-# Reload Families
+# Reload
 
 **Panel:** Families | **Button:** Reload
 
-Reload one or more families from a library directory into the current Revit project. The tool matches families by name and presents a filterable table showing how each loaded family maps to files found in the library.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reload.pushbutton/Icon.png" width="40" alt="button icon">
+
+Batch-reloads families from a library directory into the current project, through the
+FamilyReloaderUI window.
 
 ## What it does
 
-- Scans a user-selected library directory (including subdirectories) for `.rfa` files whose names match families currently loaded in the project.
-- Displays a table of all loaded families with a match status column:
-  - **ok** — exactly one matching file found in the library; family is eligible for reload.
-  - **multiple matches found** — more than one file with the same name exists; the family cannot be safely reloaded automatically.
-  - **no match** — no file with this name was found in the library.
-- Reloads all families marked **ok**, overwriting parameter values and using shared subcomponents where applicable.
+1. Lists every family in the open document in a grid.
+2. You enter a **library path** and click **Update**; the tool searches that directory for
+   `.rfa` files matching the family names and fills in a match status and the library file's
+   last-modified date.
+3. You tick the families to reload and click **Reload Families**.
+4. The window closes and the families are reloaded, with a cancellable progress bar.
+
+## Match status
+
+| Status | Meaning |
+|---|---|
+| `SingleMatch` | Exactly one matching file found — this family can be reloaded |
+| `MultipleMatches` | More than one file of that name found; the match is ambiguous |
+| `NoMatch` | No file of that name found in the library |
+
+Only families showing **`SingleMatch`** should be ticked. Resolve duplicates in the library
+before reloading the rest.
+
+## Library path
+
+- Type or paste a path, or use **Browse**.
+- **Incl Sub Directories** is a checkbox — subdirectory searching is optional, not automatic.
+- The Reload button stays disabled while the path is empty or does not exist.
+
+## Reload mode
+
+The window offers two modes:
+
+- **Import All Types On Reload** — all types in the library file are loaded, including types
+  the project does not already have.
+- **Reload Existing Types Only** — only types already in the project are updated; any type
+  the library file introduces is removed again after the reload.
+
+The mode chosen is reported in the output window before the reload starts.
 
 ## Requirements
 
-- A library directory containing `.rfa` files accessible from your workstation.
-- The library path can be changed within the tool's UI before reloading.
+- A library directory of `.rfa` files reachable from your workstation.
+- The extension's `bin` folder must be present — the window is a .NET UI loaded from there.
 
 ## Notes
 
-- Only families with a single unambiguous match are reloaded; duplicates must be resolved in the library before reloading.
-- The table is sortable and filterable so you can focus on a subset of families.
+- Right-click a column header for a filter menu; single-click to sort.
+- Library path, subdirectory setting, reload mode and column layout persist between sessions
+  in `%LocalAppData%\duHast\Reloader_settings.json`.
+- Full interface documentation: [FamilyReloaderUI user guide](../../VS/duHastUI/FamilyReloaderUI/docs/01_main_ui.md).

--- a/Samples/pyRevit/families_rename.md
+++ b/Samples/pyRevit/families_rename.md
@@ -2,49 +2,66 @@
 
 **Panel:** Families | **Menu:** Rename
 
-A pulldown containing tools to rename families and family types — both within the current Revit project and on disk in a library folder.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/Icon.png" width="40" alt="button icon">
+
+Tools to rename families and family types, in the open project or on disk in a library folder.
+
+Each tool asks for a **single CSV file**. The first row is treated as a header and ignored.
 
 ---
 
-## Rename Loaded Families
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/RenameLoadedFamilies.pushbutton/Icon.png" width="24" alt="Rename Loaded Families icon"> Rename Loaded Families
 
-Renames families that are already loaded in the open Revit project.
+Renames families already loaded in the open project.
 
-**CSV input columns:** Current family name, File path, Family category, New family name.
+**CSV columns:** Current family name, File path, Family category, New family name.
 
-The first row of the CSV is treated as a header and is ignored.
-
----
-
-## Rename Loaded Family Types
-
-Renames specific types within families loaded in the open Revit project.
-
-**CSV input columns:** Current family name, Old type name, File path, Family category, New type name.
+Family names are without the `.rfa` extension. File path may be left blank when renaming
+families inside a project.
 
 ---
 
-## Rename Families in Folder
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/RenameLoadedFamilyTypes.pushbutton/Icon.png" width="24" alt="Rename Loaded Family Types icon"> Rename Loaded Family Types
 
-Renames `.rfa` files on disk in a library directory without opening Revit.
+Renames types within families loaded in the open project.
 
-**CSV input columns:** Current family name, File path, Family category, New family name.
-
-The original files are renamed in place.
+**CSV columns:** Current family name, Old type name, File path, Family category, New type name.
 
 ---
 
-## Copy and Rename Families in Folder
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/RenameFamiliesInFolder.pushbutton/Icon.png" width="24" alt="Rename Families In Folder icon"> Rename Families In Folder
 
-Creates copies of `.rfa` files with new names and optionally places them in a different target directory.
+Renames `.rfa` files on disk in a library directory, and the family inside each file.
 
-**CSV input columns:** Current family name, File path, Family category, New family name, Target directory.
+**CSV columns:** Current family name, File path, Family category, New family name.
 
-The originals are left untouched; only the copies are renamed.
+Family category may be left blank when only renaming files.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/CopyAndRenameFamiliesInFolder.pushbutton/Icon.png" width="24" alt="Copy And Rename Families in Folder icon"> Copy And Rename Families in Folder
+
+> **Not currently available — unfinished, not merely unwired.** The button prints a greeting
+> and does nothing, and the library function behind it
+> (`lib/families/rename/copy_and_rename_families_in_folder.py`) stops part way through: it
+> asks for the CSV file and then ends without copying or renaming anything. Connecting the
+> button would not make it work.
+>
+> Use **Rename Families In Folder** on a copy of the library in the meantime.
+
+Intended behaviour: create renamed **copies** of `.rfa` files, optionally into a different
+target directory, leaving the originals untouched.
+
+**Intended CSV columns:** Current family name, File path, Family category, New family name,
+Target directory. Target directory may be left blank to copy into the same directory.
 
 ---
 
 ## Notes
 
-- All operations use a CSV file as the instruction source; prepare the CSV before running the tool.
-- Renaming on disk does not automatically update families already loaded in any open projects — use **Reload Families** afterwards if needed.
+- Prepare the CSV before running — all four tools are driven entirely by the file.
+- Renaming files on disk does not update families already loaded in any open project. Use
+  **Reload** afterwards where needed.
+- The duHast library also recognises directive files named `RenameDirective*.csv` and
+  `TypeRenameDirective*.csv` when reading a whole folder; these buttons take one file at a
+  time, so the file name does not matter here.

--- a/Samples/pyRevit/families_reports.md
+++ b/Samples/pyRevit/families_reports.md
@@ -2,66 +2,117 @@
 
 **Panel:** Families | **Menu:** Reports
 
-Reporting tools for auditing and comparing family libraries and project family data.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/Icon.png" width="40" alt="button icon">
+
+Reporting tools for auditing family libraries and project family data.
+
+## XML part atom exports come first
+
+Three of these tools do **not** read `.rfa` files. They read **XML part atom exports** —
+metadata files Revit can produce for a family without opening it. Run
+**Create XML Files Of Families** over a library before running:
+
+- Report Library Families
+- Compare Library vs Library Families
+- Compare Project vs Library Families
+
+Without the XML files those tools find nothing to report.
 
 ---
 
-## Report Library
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/CreateXMLReportLibrary.pushbutton/Icon.png" width="24" alt="Create XML Files Of Families icon"> Create XML Files Of Families
 
-Generates a comprehensive CSV report of all families found in a selected library directory.
+Generates XML part atom exports for the family files in a library directory. These are the
+input for the report and compare tools above.
 
-**Report data includes:** Family name, all type names, Revit category, and all type parameter names and values for every type.
-
-- Results are shown in the pyRevit output window.
-- The report can be saved to a CSV file.
-
-**Use when:** You need a complete inventory of a family library for documentation or QA purposes.
+An optional `xml_path_mapper.NETWORK_PATH_MAPPER` module, if importable from the extension's
+lib folder, is used to map network paths — useful where the library is reached by different
+paths from different machines.
 
 ---
 
-## Compare Project vs Library
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/CleanXMLFiles.pushbutton/Icon.png" width="24" alt="Delete orphaned XML files icon"> Delete orphaned XML files
 
-Compares the families loaded in the current Revit project against the families available in a library directory.
-
-- Only differences are reported (families or parameter values that differ between project and library).
-- Output includes family names, type names, categories, and the specific parameters that differ.
-- Report can be saved to CSV.
-
-**Use when:** You want to identify which project families are out of date compared to the library, or to check whether library updates have been applied to a project.
+Deletes XML part atom exports in a library location that no longer have a matching family
+file. Run it after families have been renamed or removed from the library so the reports do
+not carry stale entries.
 
 ---
 
-## Compare Library vs Library
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/ReportLibrary.pushbutton/Icon.png" width="24" alt="Report Library Families icon"> Report Library Families
 
-Compares families across two or more library directories.
+Reports on the families in one or more library directories, from their XML exports.
 
-- Produces a report per library showing parameter values side by side.
-- Where a family or parameter is absent from one library, the value is shown as `N/A`.
-- Report can be saved to CSV.
+- You select the library directories to process — **multiple directories** can be chosen.
+- Results are printed as a table in the output window, then a save dialog writes a CSV.
+- If more than 10,000 rows are produced, the tool warns that saving may take a while.
 
-**Use when:** You maintain multiple versions of a library (e.g., per project or per year) and need to identify what has changed between them.
+**Report data includes:** family name, type names, category, and type parameter names and
+values.
 
----
+**Optional filtering:** if a module named `settings_xml_library_writer` exposing a
+`filter_data(data)` function is importable, it is applied to the rows before they are
+reported. Use it to trim large libraries down to what you care about.
 
-## Create XML Report Library
-
-Generates XML part atom exports for family files in a library directory. These XML files are used as input by other reporting and comparison tools.
-
----
-
-## Report Project A / Report Project B
-
-Generate project-specific family reports saved to predefined output locations. Used to capture a snapshot of family data at a point in time for later comparison.
+**Use when:** You need an inventory of a library for documentation or QA.
 
 ---
 
-## Clean XML Files
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/CompareProjectvsLibrary.pushbutton/Icon.png" width="24" alt="Compare Project vs Library Families icon"> Compare Project vs Library Families
 
-Removes temporary or outdated XML export files from a directory after they are no longer needed.
+Compares the families loaded in the current project against a library, reporting **only the
+differences**.
+
+- Output includes family names, type names, categories and the specific parameters that
+  differ.
+- Results are printed as a table, then a save dialog writes a CSV.
+
+**Use when:** Identifying which project families have fallen behind the library.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/CompareLibraryVsLibrary.pushbutton/Icon.png" width="24" alt="Compare Library vs Library Families icon"> Compare Library vs Library Families
+
+Compares families across two or more libraries.
+
+- One column per library, showing each parameter's value in that library.
+- Where a family, type or parameter is absent from a library, the value is shown as `N/A`.
+- Results are printed as a table, then a save dialog writes a CSV.
+
+**Use when:** Maintaining several versions of a library and needing to see what has diverged.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/ReportProjectA.pushbutton/Icon.png" width="24" alt="Report Placed Families icon"> Report Placed Families
+
+Reports on the families placed in the current project, including instance counts by type.
+
+> **Configure before first use.** This report only covers the parameters listed in
+> `FAMILY_PARAMETERS_TO_REPORT` in
+> `Extensions/duHast-2025.extension/duHast.tab/lib/families/report.py`. That list currently
+> holds placeholders — `"Sample Parameter One"`, `"Sample Parameter Two"`,
+> `"Sample Parameter Three"` — so as shipped the report returns no useful parameter columns.
+> Replace them with your project's parameter names.
+
+Results are printed as a table, then a save dialog writes a CSV.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/ReportProjectB.pushbutton/Icon.png" width="24" alt="Report Loaded Families icon"> Report Loaded Families
+
+Reports on the families loaded in the current project via XML part atom export of the
+project's families — a different mechanism to **Report Placed Families**, which reads the
+families directly.
+
+**Report data includes:** family name, type name, category, and type parameters and values.
+
+Results are printed as a table, then a save dialog writes a CSV.
 
 ---
 
 ## Notes
 
-- **Create XML Report Library** must be run before **Compare Library vs Library** and **Compare Project vs Library**, as those tools read the XML exports rather than the `.rfa` files directly.
-- Large libraries may take several minutes to process; progress is shown in the pyRevit output window.
+- Neither project report writes to a fixed location; both ask where to save.
+- Large libraries take several minutes; progress is shown in a cancellable progress bar.
+- The two optional hook modules (`settings_xml_library_writer`, `xml_path_mapper`) are looked
+  up on import and ignored if absent — no error is raised if you do not use them.

--- a/Samples/pyRevit/families_swap.md
+++ b/Samples/pyRevit/families_swap.md
@@ -1,43 +1,67 @@
 # Swap Families
 
-**Panel:** Families | **Menu:** Rename > Swap (also accessible as SwapFamilies)
+**Panel:** Families | **Menu:** SwapFamilies
 
-Tools to replace instances of one family type with instances of another family type within the current Revit project.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/SwapFamilies.pulldown/Icon.png" width="40" alt="button icon">
 
----
+Tools to replace instances of one family type with another in the current project.
 
-## Swap By Directives
+All three report, as tables in the output window, the instances they could **not** swap:
 
-Swaps family instances based on a CSV file containing explicit swap instructions.
+| Table | Meaning |
+|---|---|
+| Host Families containing instances not swapped | Instances nested inside another family |
+| Host Groups containing instances not swapped | Instances inside a group |
 
-**CSV input:** A mapping of source family/type to target family/type. Each row defines one substitution rule.
-
-- Processes all eligible instances in the project matching the source type.
-- Reports any instances inside groups or as nested families that cannot be swapped automatically.
-
-**Use when:** You have a predefined list of substitutions to apply across a project, for example when updating a design from concept families to construction-issue families.
+Those need resolving by hand — swapping nested and grouped instances is not automated.
 
 ---
 
-## Swap By User Selection List
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/SwapFamilies.pulldown/Swap%20By%20Directives.pushbutton/Icon.png" width="24" alt="Swap By Directives icon"> Swap By Directives
 
-Swaps family instances using an interactive selection workflow.
+Swaps instances according to CSV instruction files.
 
-1. A dialog presents a list of family types loaded in the project; select the **source** type to replace.
-2. A second dialog presents available types; select the **target** type to use instead.
-3. All eligible instances of the source type are replaced with the target type.
+**You select a folder, not a file.** The tool searches it for files whose names begin with
+`SwapDirective` and end in `.csv`, and reads every directive it finds across all of them.
 
-Instances inside groups or nested families are reported but not swapped.
+**Directive file columns:**
+
+```
+Source Family Name, Source Family Category Name, Source Family Type Name,
+Target Family Name, Target Family Type Name
+```
+
+**Use when:** You have a predefined substitution list to apply across a project — for example
+moving from concept families to construction-issue families.
 
 ---
 
-## Swap By User Selection Pick
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/SwapFamilies.pulldown/Swap%20By%20User%20Selection%20List.pushbutton/Icon.png" width="24" alt="Swap By Selection icon"> Swap By Selection
 
-Similar to **Swap By User Selection List** but uses a pick-in-canvas interaction to identify the source instance before presenting the target type list.
+Swaps instances through two selection dialogs:
+
+1. Select the **source** family type to replace, from the types loaded in the project.
+2. Select the **target** type to use instead. The list is filtered to the source type's
+   category.
+3. All eligible instances of the source type are swapped.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/SwapFamilies.pulldown/Swap%20By%20User%20Selection%20Pick.pushbutton/Icon.png" width="24" alt="Swap By Picking icon"> Swap By Picking
+
+The same as **Swap By Selection**, except the source is identified by **picking an instance
+in the model** rather than choosing from a list. You then select the target type as before.
+
+Afterwards it offers to **save the swap you just performed as a `SwapDirective` CSV** through
+a save dialog. That file can be fed straight back into **Swap By Directives**, so a one-off
+pick can be recorded and replayed on other models.
 
 ---
 
 ## Notes
 
-- Nested families and families inside groups cannot be swapped automatically; resolve those manually.
-- Instance parameters are preserved where the parameter exists on the target type; type parameters are taken from the target type.
+- Instances nested in families or inside groups cannot be swapped automatically; they are
+  reported for manual attention.
+- Instance parameter values are preserved where the target type carries a parameter of the
+  same name. Type parameters come from the target type.
+- Progress is shown in a cancellable progress bar.

--- a/Samples/pyRevit/grids.md
+++ b/Samples/pyRevit/grids.md
@@ -1,68 +1,91 @@
 # Grids
 
-**Panel:** Grids and Levels | **Menu:** Grids
+**Panel:** Grids And Levels | **Menu:** Grids
 
-Tools for controlling grid bubble visibility and grid display mode in the active Revit view.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Icon.png" width="40" alt="button icon">
 
----
+Tools for controlling grid bubble visibility and grid extents in the active view.
 
-## All 0 Bubbles On
-
-Shows the grid bubble at the **start end** (end 0) of every grid in the active view.
+All of these act on the **active view** only, and on the grids visible in it.
 
 ---
 
-## All 1 Bubbles On
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/All%200%20Bubbles%20On.pushbutton/Icon.png" width="24" alt="Show Bubbles Start icon"> Show Bubbles Start
 
-Shows the grid bubble at the **finish end** (end 1) of every grid in the active view.
-
----
-
-## All Bubbles Off
-
-Hides grid bubbles at **both ends** of every grid in the active view.
+Switches **on** the bubble at the start end (end 0) of every grid visible in the active view.
+It only turns bubbles on; it never turns one off.
 
 ---
 
-## All 2D
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/All%201%20Bubbles%20On.pushbutton/Icon.png" width="24" alt="Show Bubbles End icon"> Show Bubbles End
 
-Switches every grid in the active view to **2D** mode, so that changes to grid extents and bubble visibility in this view do not affect other views.
+Switches **on** the bubble at the finish end (end 1) of every grid visible in the active view.
 
 ---
 
-## Propagate Grids
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/All%20Bubbles%20Off.pushbutton/Icon.png" width="24" alt="All Bubbles Off icon"> All Bubbles Off
 
-Copies grid bubble visibility, extent overrides, and bubble-end settings from the **active view** to one or more selected target views.
+Hides the bubbles at **both ends** of every grid visible in the active view.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/All%202D.pushbutton/Icon.png" width="24" alt="All Grids to 2D icon"> All Grids to 2D
+
+Sets both ends of every grid visible in the active view to **2D**, so that extent and bubble
+changes made in this view no longer affect other views.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Toggle%200%20Bubbles%20By%20Selection.pushbutton/Icon.png" width="24" alt="Toggle Bubbles Start icon"> Toggle Bubbles Start
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Toggle%201%20Bubbles%20By%20Selection.pushbutton/Icon.png" width="24" alt="Toggle Bubbles End icon"> Toggle Bubbles End
+
+Toggles the bubble at end 0 (Start) or end 1 (End) for **grids you pick**.
+
+Run the tool first — it starts a pick prompt ("Select Grids") filtered to the Grids category.
+Pick the grids, finish the selection, and their bubbles at that end are flipped: on becomes
+off, off becomes on. There is no need to pre-select anything before launching.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Extend%20Grids.pushbutton/Icon.png" width="24" alt="Extend Grids icon"> Extend Grids
+
+Extends linear grids in the active view out to the **view's crop box**.
+
+**Requirements:**
+
+- The active view must be a **Floor Plan, Ceiling Plan or Area Plan**.
+- The view's **crop box must be enabled** — the crop region is what the grids are extended to.
+- Only linear grids are handled; arc grids are left alone.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Propagate%20Grids.pushbutton/Icon.png" width="24" alt="Propagate Grids icon"> Propagate Grids
+
+Copies grid bubble visibility and grid extents from the **active view** to views you select.
 
 **Workflow:**
-1. Set up grid display exactly as required in the source plan view.
+
+1. Set the grid display up exactly as you want it in the source view.
 2. Run **Propagate Grids**.
-3. Select the target views to apply the same settings to.
+3. Select the target views from the list — entries are shown as `view name (view type)`.
 
-**Use when:** You want all floor plan views in a project to share consistent grid display without adjusting each view manually.
+**Requirements:**
 
----
+- The **active view** must be a Floor Plan, Ceiling Plan or Area Plan; the tool exits with an
+  "Unsupported active view type" message otherwise.
+- Only Floor Plans, Ceiling Plans and Area Plans are offered as targets. Sections, elevations
+  and 3D views cannot be targeted.
 
-## Extend Grids
-
-Extends the visible length of grids in the active view to match a defined boundary or extent.
-
----
-
-## Toggle 0 Bubbles By Selection
-
-Toggles the bubble at **end 0** of only the grids you have selected before running the tool. Runs on the active view.
-
----
-
-## Toggle 1 Bubbles By Selection
-
-Toggles the bubble at **end 1** of only the grids you have selected before running the tool. Runs on the active view.
+Progress is shown in a cancellable progress bar.
 
 ---
 
 ## Notes
 
-- All tools act on the **active view** only unless stated otherwise.
-- Grid changes made in 3D mode affect all views; switch to 2D mode first with **All 2D** if you need view-specific control.
-- **Propagate Grids** is the most efficient way to apply a consistent grid layout across many views at once.
+- Grids set to 3D share their extents across views. Run **All Grids to 2D** in a view first if
+  you want changes there to stay local to it.
+- **Propagate Grids** is the efficient way to apply one grid setup across many plan views;
+  the per-view tools above are for setting up that one source view.
+- If a tool reports "No grids visible in view", check the view's crop, view range and category
+  visibility — the tools only see grids the view actually shows.

--- a/Samples/pyRevit/levels.md
+++ b/Samples/pyRevit/levels.md
@@ -1,49 +1,60 @@
 # Levels
 
-**Panel:** Grids and Levels | **Menu:** Levels
+**Panel:** Grids And Levels | **Menu:** Levels
 
-Tools for controlling level header (bubble) visibility and level display mode in the active Revit view.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/Icon.png" width="40" alt="button icon">
 
----
+Tools for controlling level header visibility and level extents in the active view.
 
-## All 0 Headers On
-
-Shows the level header at the **start end** (end 0) of every level in the active view.
-
----
-
-## All 1 Headers On
-
-Shows the level header at the **finish end** (end 1) of every level in the active view.
+All of these act on the **active view** only, and on the levels visible in it. They are the
+level counterparts of the [Grids](grids.md) tools and follow the same start/end convention —
+but note there is no level equivalent of *Extend Grids* or *Propagate Grids*.
 
 ---
 
-## All Headers Off
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/All%200%20Headers%20On.pushbutton/Icon.png" width="24" alt="Show Headers Start icon"> Show Headers Start
 
-Hides level headers at **both ends** of every level in the active view.
-
----
-
-## All 2D
-
-Switches every level in the active view to **2D** mode, so that changes to level extents and header visibility in this view do not affect other views.
+Switches **on** the header at the start end (end 0) of every level visible in the active view.
+It only turns headers on; it never turns one off.
 
 ---
 
-## Toggle 0 Headers By Selection
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/All%201%20Headers%20On.pushbutton/Icon.png" width="24" alt="Show Headers End icon"> Show Headers End
 
-Toggles the header at **end 0** of only the levels you have selected before running the tool. Runs on the active view.
+Switches **on** the header at the finish end (end 1) of every level visible in the active view.
 
 ---
 
-## Toggle 1 Headers By Selection
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/All%20Headers%20Off.pushbutton/Icon.png" width="24" alt="All Heads Off icon"> All Heads Off
 
-Toggles the header at **end 1** of only the levels you have selected before running the tool. Runs on the active view.
+Hides the headers at **both ends** of every level visible in the active view.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/All%202D.pushbutton/Icon.png" width="24" alt="All Levels to 2D icon"> All Levels to 2D
+
+Sets both ends of every level visible in the active view to **2D**, so that extent and header
+changes made in this view no longer affect other views.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/Toggle%200%20Headers%20By%20Selection.pushbutton/Icon.png" width="24" alt="Toggle Headers Start icon"> Toggle Headers Start
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/Toggle%201%20Headers%20By%20Selection.pushbutton/Icon.png" width="24" alt="Toggle Headers End icon"> Toggle Headers End
+
+Toggles the header at end 0 (Start) or end 1 (End) for **levels you pick**.
+
+Run the tool first — it starts a pick prompt ("Select levels") filtered to the Levels
+category. Pick the levels, finish the selection, and their headers at that end are flipped.
+There is no need to pre-select anything before launching.
 
 ---
 
 ## Notes
 
-- All tools act on the **active view** only.
-- Level changes made in 3D mode affect all views; use **All 2D** first to confine changes to the current view.
-- These tools are the level equivalent of the **Grids** bubble tools and follow the same end-0 / end-1 convention.
+- Levels are visible in section and elevation views, so that is where these tools are
+  normally used.
+- Levels set to 3D share their extents across views. Run **All Levels to 2D** in a view first
+  if you want changes there to stay local to it.
+- If a tool reports no levels in the view, check the view's crop, extents and category
+  visibility — the tools only see levels the view actually shows.

--- a/Samples/pyRevit/purge_unused.md
+++ b/Samples/pyRevit/purge_unused.md
@@ -2,79 +2,95 @@
 
 **Panel:** Purge Unused | **Menu:** Purge
 
-Tools to remove unused graphic styles, patterns, parameters, views, and templates from the current Revit model, reducing file size and improving model cleanliness.
+<img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Icon.png" width="40" alt="button icon">
 
-Each tool comes in two variants: a **standard** version that processes everything automatically, and a **By Selection** version that shows a list and lets you choose which items to remove.
+Tools to remove unused graphic styles, patterns, parameters, views and templates from the
+current model.
 
----
+**Every tool in this menu asks you what to remove before it deletes anything.** None of them
+runs unattended. What differs is *how* they decide what to offer you.
 
-## Purge Line Styles
+## Two families of tool
 
-Removes all line styles that are not referenced by any element in the model.
+**Try-and-delete tools** — Line Styles, Line Patterns, Fill Patterns, Shared Parameters.
+These attempt to delete each candidate and keep only the deletions Revit accepts; anything
+still in use is rejected and survives. Each has a plain button that sweeps everything of that
+kind, and a **By Selection** twin that runs the same sweep restricted to items you pick.
 
-Uses a try-and-rollback method: it attempts to delete each style and confirms whether Revit allows the deletion (used styles are rejected). Only confirmed unused styles are permanently removed.
-
-**By Selection variant:** Presents a list of candidate line styles so you can choose which ones to remove.
-
----
-
-## Purge Fill Patterns
-
-Removes all fill patterns not used by any material, surface pattern, or element override in the model.
-
-**By Selection variant:** Presents a list so you can choose which fill patterns to remove.
+**List-and-choose tools** — Filters, Unplaced Legends, Unplaced Schedules, Templates,
+Unplaced Views. These work out the unused items up front and present that list for you to
+choose from. There is no By Selection twin because the selection *is* the tool.
 
 ---
 
-## Purge Line Patterns
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Line%20Styles.pushbutton/Icon.png" width="24" alt="Line Styles icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Line%20Styles%20By%20Selection.pushbutton/Icon.png" width="24" alt="Line Styles By selection icon"> Line Styles / Line Styles By selection
 
-Removes all line patterns not used by any line style, grid, level, or other element in the model.
+Removes line styles not referenced by any element.
 
-**By Selection variant:** Presents a list so you can choose which line patterns to remove.
-
----
-
-## Purge Shared Parameters
-
-Removes shared parameter definitions that are not bound to any element category in the current project.
-
-**By Selection variant:** Presents a list so you can choose which shared parameters to remove.
+The **By Selection** variant lists **every** line style in the model, not just the unused
+ones — the try-and-delete pass still refuses to remove any that are in use, so a selection
+that includes used styles is safe, it simply won't remove them.
 
 ---
 
-## Purge Unused Filters
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Fill%20Patterns.pushbutton/Icon.png" width="24" alt="Fill Patterns icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Fill%20Patterns%20By%20Selection.pushbutton/Icon.png" width="24" alt="Fill Patterns By Selection icon"> Fill Patterns / Fill Patterns By Selection
 
-Removes view filters that are not assigned to any view or view template in the model.
-
----
-
-## Purge Unused Legends
-
-Removes legend views that are not placed on any sheet.
+Removes fill patterns not used by any material, surface pattern or element override. Same
+selection behaviour as line styles.
 
 ---
 
-## Purge Unused Schedules
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Line%20Patterns.pushbutton/Icon.png" width="24" alt="Line Patterns icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Line%20Patterns%20By%20Selection.pushbutton/Icon.png" width="24" alt="Line Patterns By Selection icon"> Line Patterns / Line Patterns By Selection
 
-Removes schedule views that are not placed on any sheet.
-
----
-
-## Purge Unused Templates
-
-Removes view templates that are not applied to any view in the model.
+Removes line patterns not used by any line style, grid, level or other element. Same
+selection behaviour as line styles.
 
 ---
 
-## Purge Unplaced Views
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Shared%20Parameters.pushbutton/Icon.png" width="24" alt="Shared Parameters icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Shared%20Parameters%20By%20Selection.pushbutton/Icon.png" width="24" alt="Shared Parameters by Selection icon"> Shared Parameters / Shared Parameters by Selection
 
-Removes all views (floor plans, sections, elevations, 3D views, etc.) that are not placed on any sheet.
+Removes shared parameter definitions not bound to any category in the project. Same
+selection behaviour as line styles.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Unused%20Filters.pushbutton/Icon.png" width="24" alt="Filters icon"> Filters
+
+Collects view filters not assigned to any view or view template, then asks which of them to
+purge.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Unused%20Legends.pushbutton/Icon.png" width="24" alt="Unplaced Legends icon"> Unplaced Legends
+
+Collects legend views not placed on any sheet, then asks which to purge.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Unused%20Schedules.pushbutton/Icon.png" width="24" alt="Unplaced Schedules icon"> Unplaced Schedules
+
+Collects schedule views not placed on any sheet, then asks which to purge.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Unused%20Templates.pushbutton/Icon.png" width="24" alt="Templates icon"> Templates
+
+Collects view templates not applied to any view, then asks which to purge.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Purge%20Unplaced%20Views.pushbutton/Icon.png" width="24" alt="Unplaced Views icon"> Unplaced Views
+
+Collects views not placed on any sheet — floor plans, sections, elevations, 3D views — then
+asks which to purge.
 
 ---
 
 ## Notes
 
-- Always save or create a model backup before running purge operations — deletions cannot be undone after saving.
-- **By Selection** variants are recommended when you are unsure which items are safe to remove.
-- Running Revit's built-in **Purge Unused** command after these tools can further reduce file size.
-- These tools target specific element types; they do not replace a full model audit.
+- Save or back up the model before purging. Deletions cannot be undone once the file is saved.
+- The list-and-choose tools show nothing to select when there is nothing unused of that kind;
+  they report so and exit.
+- Running Revit's built-in **Purge Unused** afterwards can free up further items these tools
+  do not target.
+- These tools cover specific element types. They are not a substitute for a full model audit.

--- a/Samples/pyRevit/pushit_area_by_room.md
+++ b/Samples/pyRevit/pushit_area_by_room.md
@@ -2,12 +2,14 @@
 
 **Panel:** PushIt | **Button:** Verify Push It Area
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Area%20By%20Room.pushbutton/Icon.png" width="40" alt="button icon">
+
 Measures each mock room by briefly placing a real Revit room inside it, writes the measured
 area back onto the mock room, and deletes the temporary rooms again.
 
 ## What it does
 
-For every mock room in the **active** model:
+Asks you to select which mock rooms to verify, then for each selected mock room:
 
 1. Places a temporary Revit room at the mock room's location.
 2. Reads the room's area and perimeter.
@@ -29,7 +31,9 @@ For every mock room in the **active** model:
 5. Deletes all temporary Revit rooms it created.
 
 A mock room whose temporary room comes back with an area of zero — usually because the
-location is not enclosed — is reported and left unchanged.
+location is not enclosed — is reported and left unchanged. Mock rooms whose centroid cannot
+be determined are dropped from the run before it starts, with a count printed to the output
+window.
 
 ## When to use this
 

--- a/Samples/pyRevit/pushit_get_a_room.md
+++ b/Samples/pyRevit/pushit_get_a_room.md
@@ -2,12 +2,14 @@
 
 **Panel:** PushIt | **Button:** Get A Room! / Settings (split button)
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/GetARoom.splitbutton/Icon.png" width="40" alt="button icon">
+
 Builds new mock room families from filled regions drawn in the model, then loads and places
 them.
 
 ---
 
-## Get A Room! (main button)
+## <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/GetARoom.splitbutton/GetARoom.pushbutton/Icon.png" width="24" alt="Get A Room! icon"> Get A Room! (main button)
 
 This tool **authors Revit family files on disk**. It does not place instances of an existing
 mock room family — it creates a new set of family files for every filled region you select.
@@ -48,7 +50,7 @@ mock room family — it creates a new set of family files for every filled regio
 
 ---
 
-## Settings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/GetARoom.splitbutton/Settings.pushbutton/Icon.png" width="24" alt="Settings icon"> Settings
 
 Stores **one value** in the model: the directory the generated family files are written to.
 

--- a/Samples/pyRevit/pushit_main.md
+++ b/Samples/pyRevit/pushit_main.md
@@ -1,6 +1,8 @@
-# PushIt
+# Push It!
 
-**Panel:** PushIt | **Button:** PushIt
+**Panel:** PushIt | **Button:** Push It!
+
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/PushIt.pushbutton/Icon.png" width="40" alt="button icon">
 
 Opens the **PushIt** WPF application — the main interface for loading room data from an external source (CSV or drofus API) and pushing parameter values into mock room families in the open Revit document.
 
@@ -22,4 +24,5 @@ Use this button as the primary PushIt workflow tool whenever you need to synchro
 ## Notes
 
 - Configure your data source (CSV path or drofus credentials) via **⚙ Settings** inside the PushIt window before loading data.
+- The window is a .NET UI loaded from the extension's `bin` folder at run time. If that folder is missing or incomplete the button fails immediately with a message about the bin directory.
 - See the [PushIt user guide](../../VS/duHastRevitApplications/PushIt/docs/01_main_ui.md) for full interface documentation.

--- a/Samples/pyRevit/pushit_place_revit_rooms.md
+++ b/Samples/pyRevit/pushit_place_revit_rooms.md
@@ -2,20 +2,60 @@
 
 **Panel:** PushIt | **Button:** Place Revit Rooms
 
-Creates native Revit rooms at the locations of existing mock room family instances, using the mock room data to populate room properties.
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/PlaceRevitRooms.pushbutton/Icon.png" width="40" alt="button icon">
+
+Creates native Revit rooms at the locations of mock rooms, copying the mock room data into
+them. The mock rooms can live in the current model **or in a Revit link**.
 
 ## What it does
 
-- Reads each mock room family instance's position, boundary, and parameter data.
-- Places a native Revit room element at the corresponding location in the model.
-- Copies relevant parameter values (room name, number, department, etc.) from the mock room into the Revit room.
+1. **Select the source model** — a document picker offers the active document and every loaded
+   Revit link. Choose the one holding the mock rooms.
+2. **Select the mock rooms** to convert, from a multi-select list.
+3. **Select the model insertion method**:
+   - **Origin to Origin** — no transform is applied;
+   - **By Shared Coordinates** — the source model's translation and rotation are read and
+     applied, so the rooms land in the right place.
+
+   This only matters when the mock rooms come from a link. Choose the option matching how the
+   link was inserted, or the rooms will be placed in the wrong location.
+4. Rooms are created in the **current** model at each mock room's centroid, and the mapped
+   parameter values are transferred.
+
+Mock rooms whose centroid cannot be determined are **dropped before placement**, with a count
+reported. If none of the selected rooms yields a centroid the tool stops.
+
+## Parameter transfer
+
+Mock room `duHast_*` parameters are mapped onto the equivalent Revit room built-in
+parameters, including:
+
+| Mock room parameter | Revit room parameter |
+|---|---|
+| `duHast_room_number` | Room Number |
+| `duHast_room_name` | Room Name |
+| `duHast_department_name` | Department |
+
+A room can be created successfully and still fail to receive every parameter value; the
+output window reports both counts separately.
 
 ## When to use this
 
-Use this button when you need native Revit rooms for area scheduling, room tagging, or other workflows that require the built-in Revit room type — while keeping the mock rooms as the primary design layout tool.
+Use this when you need native Revit rooms — for area schedules, room tags, or anything that
+requires the built-in room element — while continuing to use mock rooms as the design layout
+tool.
+
+## Requirements
+
+- Revit rooms need enclosed boundaries to calculate an area. Walls, room separation lines or
+  area boundaries must exist at the mock room locations in the **current** model.
+- The PushIt data source and unique-ID parameter must be configured; the tool exits with a
+  message if either cannot be read.
+- When reading from a link, that link must be loaded.
 
 ## Notes
 
-- Revit rooms require a closed boundary to calculate area correctly; ensure the mock room locations have valid room boundaries (walls, room separation lines, or area boundaries).
-- If a room already exists at a mock room's location, a duplicate may be created — review the model after running.
-- Run **Area By Room** after this tool to verify that the placed Revit rooms match the expected areas from the mock room data.
+- Existing rooms are not detected. Running twice over the same locations creates duplicates —
+  check the model afterwards.
+- Run [Verify Push It Area](pushit_area_by_room.md) afterwards to check the placed geometry
+  against the mock room areas.

--- a/Samples/pyRevit/pushit_stats.md
+++ b/Samples/pyRevit/pushit_stats.md
@@ -2,6 +2,8 @@
 
 **Panel:** PushIt | **Menu:** Stats
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Stats.pulldown/Icon.png" width="40" alt="button icon">
+
 Two reporting tools covering the mock room families in the current model. Both print tables
 to the pyRevit output window and change nothing in the model.
 
@@ -10,7 +12,7 @@ source configuration, and report on the family instances found in those categori
 
 ---
 
-## Stats
+## <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Stats.pulldown/StatsSimple.pushbutton/Icon.png" width="24" alt="Stats icon"> Stats
 
 Prints three tables:
 
@@ -31,7 +33,7 @@ created or currently owns them.
 
 ---
 
-## Stats By Design Set And Option
+## <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Stats.pulldown/IdsByDesignSetAndOption.pushbutton/Icon.png" width="24" alt="Stats By Design Set And Option icon"> Stats By Design Set And Option
 
 A data quality check, not a listing. It groups the mock rooms by their unique-ID parameter
 value and reports only the values that appear in **more than one design set** — instances

--- a/Samples/pyRevit/pushit_swap_dimensions.md
+++ b/Samples/pyRevit/pushit_swap_dimensions.md
@@ -1,21 +1,42 @@
-# Swap Width and Depth
+# Swap Width And Depth
 
-**Panel:** PushIt | **Button:** Swap Width and Depth
+**Panel:** PushIt | **Button:** Swap Width And Depth
 
-Swaps the width and depth instance parameter values on selected mock room family instances.
+<img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/SwapWidthAndDepth.pushbutton/Icon.png" width="40" alt="button icon">
+
+Swaps the width and depth values on picked mock rooms **and rotates them 90 degrees**, so the
+room keeps its footprint but changes orientation.
 
 ## What it does
 
-- Takes the current **Width** parameter value and assigns it to **Depth**, and vice versa.
-- Operates on all selected mock room family instances in one step.
-- The family geometry updates immediately to reflect the swapped dimensions.
+1. Starts a pick prompt — *"Select push it rooms"* — filtered to the **Walls** and **Columns**
+   categories, which is how mock rooms are modelled.
+2. For each picked element, in a cancellable progress bar:
+   - reads `duHast_width` and `duHast_depth`;
+   - writes each value into the other parameter;
+   - **rotates the element 90 degrees about its origin**.
+
+The rotation is the point of the tool: swapping the two dimensions alone would leave the
+geometry facing the wrong way, so the element is turned to match.
 
 ## When to use this
 
-Use this button when a mock room has been placed with the correct footprint area but its orientation is 90° off from what the room data expects — swapping width and depth corrects the dimensional assignment without moving or recreating the family.
+Use this when a mock room has the right area but its width and depth are the wrong way round
+relative to the room data — the long side runs the wrong way.
+
+## Requirements
+
+- The mock rooms must carry instance parameters named exactly **`duHast_width`** and
+  **`duHast_depth`**. An element missing either is reported as *"One of the parameters does
+  not exist on the selected element. Ignoring pairing"* and left alone.
+- The elements must be of category **Walls** or **Columns**; nothing else can be picked.
+- **The element's origin must be at its centre**, defined by reference planes. The rotation is
+  about the origin, so an off-centre origin moves the mock room as well as turning it.
 
 ## Notes
 
-- Select one or more mock room family instances in the canvas before running the tool.
-- Only instance parameters named **Width** and **Depth** are affected; other parameters are unchanged.
-- If the family uses different parameter names for these dimensions, the tool may not produce the expected result.
+- Selection happens after launching the tool, through the pick prompt. Pre-selecting in the
+  canvas is not required.
+- If either parameter fails to set, the rotation is skipped for that element so the geometry
+  and the values do not fall out of step.
+- Each element's before and after values are printed to the output window.

--- a/Samples/pyRevit/readme.md
+++ b/Samples/pyRevit/readme.md
@@ -1,136 +1,22 @@
 # duHast pyRevit Extension
 
-A pyRevit toolbar extension for Revit, providing automation tools for BIM workflows across family management, export, view management, model maintenance, and more.
+A pyRevit toolbar extension for Revit, providing automation tools for BIM workflows across
+family management, export, view management, model maintenance, and more.
 
 ---
 
 ## Toolbar Panels
 
-### Families
+Panels and button groups are listed in **ribbon order**, matching the extension's bundle
+layouts. Names are the labels shown in Revit.
 
-Tools for loading, saving, renaming, swapping, and reporting on Revit families and type catalogue files.
+### About
 
-| Button Group | Description |
-|---|---|
-| [Reload](families_reload.md) | Reload families from a library folder, with match-status filtering |
-| [Rename](families_rename.md) | Rename loaded families and types, or rename files in a library folder |
-| [Load / Save](families_io.md) | Bulk-load families into the project, or save families out to a folder |
-| [Catalogue Files](families_catalogue_files.md) | Export and clean type catalogue files; strip a family back to a single catalogue placeholder type |
-| [Force Update](families_force_update.md) | Force Revit to detect a family as changed when source files have been overwritten |
-| [Change Category](families_change_category.md) | Reassign the open family to a different Revit category, preserving subcategories |
-| [Swap](families_swap.md) | Replace family instances with a different family, by CSV directive or interactive selection |
-| [Reports](families_reports.md) | Generate, compare, and export reports on family libraries and projects |
-| [At The Library](families_at_the_library.md) | Open the AtTheLibrary tool for managing shared type catalogue parameters |
+Reference links. Neither button touches the model.
 
----
-
-### Export
-
-Tools for exporting sheets to PDF and DWG, comparing export sets, and managing document metadata.
-
-| Button Group | Description |
-|---|---|
-| [PDF / DWG Export](export_pdf_dwg.md) | Export sheets to PDF and/or DWG with configurable naming rules and print sets |
-| [Compare](export_compare.md) | Check the sheets in a Revit schedule against the PDF files in a folder |
-| [DocManager](export_docmanager.md) | Manage document properties and revision data for export records |
-
----
-
-### Grids
-
-Tools for controlling grid bubble visibility and 2D/3D extent behaviour.
-
-| Button Group | Description |
-|---|---|
-| [Grids](grids.md) | Toggle grid bubbles on/off at ends 0 and 1, switch to 2D, propagate and extend grids |
-
----
-
-### Levels
-
-Tools for controlling level header visibility and 2D/3D extent behaviour.
-
-| Button Group | Description |
-|---|---|
-| [Levels](levels.md) | Toggle level headers on/off at ends 0 and 1, switch to 2D |
-
----
-
-### Warnings
-
-Tools for resolving and highlighting common Revit warnings related to rooms, areas, and annotation.
-
-| Button Group | Description |
-|---|---|
-| [Solve Warnings](warnings_solve.md) | Fix room tags outside rooms, duplicate marks, and overlapping separation lines |
-| [Highlight Warnings](warnings_highlight.md) | Report area and room separation lines carrying warnings, and colour-highlight them in the active view |
-
----
-
-### View Templates
-
-Tools for importing, exporting, and applying view templates, filters, and graphic overrides.
-
-| Button Group | Description |
-|---|---|
-| [Import / Export](view_templates_import_export.md) | Export and import view templates, view filters, and colour schemes to/from JSON |
-| [Modify](view_templates_modify.md) | Apply filter overrides and graphic overrides to view templates in bulk |
-
----
-
-### PushIt
-
-Tools for managing mock rooms (room-like generic model families) and their associated data.
-
-| Button Group | Description |
-|---|---|
-| [PushIt](pushit_main.md) | Open the PushIt application for managing mock room data |
-| [Get A Room!](pushit_get_a_room.md) | Build mock room families from filled regions; set the family output directory |
-| [Swap Dimensions](pushit_swap_dimensions.md) | Swap the Width and Depth parameter values on selected mock rooms |
-| [Stats](pushit_stats.md) | Report mock room counts by family, creator and owner; flag IDs duplicated across design sets |
-| [Place Revit Rooms](pushit_place_revit_rooms.md) | Create native Revit rooms at the locations of mock rooms |
-| [Verify Push It Area](pushit_area_by_room.md) | Measure mock rooms with temporary Revit rooms and write the area back onto them |
-
----
-
-### Purge
-
-Tools for purging unused elements from the model to reduce file size and improve performance.
-
-| Button Group | Description |
-|---|---|
-| [Purge Unused](purge_unused.md) | Purge unused line styles, fill patterns, line patterns, shared parameters, filters, legends, schedules, view templates, and unplaced views — with or without pre-selection |
-
----
-
-### Data Collectors
-
-Scripts for exporting model data to file for reporting and audit purposes.
-
-| Button Group | Description |
-|---|---|
-| [Data Collectors](data_collectors.md) | Collect and export rooms, sheets, ceilings, and levels data to file |
-
----
-
-### Ceilings
-
-Tools for generating ceiling elements from room boundaries.
-
-| Button Group | Description |
-|---|---|
-| [Ceilings By Rooms](ceilings_by_rooms.md) | Automatically create ceiling elements for every room in the model |
-
----
-
-### Walls
-
-Tools that relate walls and facade openings back to the rooms they bound.
-
-| Button Group | Description |
-|---|---|
-| [Walls By Room](walls_by_rooms.md) | Write the room number onto the walls bounding each selected room |
-| [Facade Opening To Room](walls_facade_opening.md) | Report external wall and window opening areas per room to CSV |
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/About.panel/About.pulldown/Icon.png" width="20" alt=""> | [About](about.md) | Open the extension licence on GitHub, or the Icons8 site the icons come from |
 
 ---
 
@@ -138,32 +24,191 @@ Tools that relate walls and facade openings back to the rooms they bound.
 
 Tools for working with cloud-hosted Revit models.
 
-| Button Group | Description |
-|---|---|
-| [Cloud GUIDs](cloud_guids.md) | Retrieve the cloud project and model GUIDs for use in Revit Batch Processor task files |
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Cloud.panel/GUIDS.pushbutton/Icon.png" width="20" alt=""> | [GUIDS](cloud_guids.md) | Retrieve cloud project and model GUIDs for the model and all its links, for Revit Batch Processor task files |
 
 ---
 
-### Views — Schedules
+### Grids And Levels
+
+Tools for controlling grid bubble and level header visibility, and 2D/3D extent behaviour, in
+the active view.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Grids.pulldown/Icon.png" width="20" alt=""> | [Grids](grids.md) | Show or toggle grid bubbles at either end, switch grids to 2D, extend grids to the view crop, propagate grid setup to other plan views |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Grids%20And%20Levels.panel/Levels.pulldown/Icon.png" width="20" alt=""> | [Levels](levels.md) | Show or toggle level headers at either end, switch levels to 2D |
+
+---
+
+### View Templates
+
+Tools for propagating and transferring view template settings, filters and colour schemes.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Icon.png" width="20" alt=""> | [Modify](view_templates_modify.md) | Propagate filter and category overrides from a source view template to many others; delete filters from templates |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Icon.png" width="20" alt=""> | [Import Export](view_templates_import_export.md) | Export and import view template overrides and view filters as JSON, and colour fill scheme values as CSV |
+
+---
+
+### Views
 
 Tools for managing Revit schedules on sheets and in views.
 
-| Button Group | Description |
-|---|---|
-| [Schedules](views_schedules.md) | Manage column widths; report and fix schedule segment overlaps on sheets; export, extract, and import Room: Number filter values |
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Icon.png" width="20" alt=""> | [Schedules](views_schedules.md) | Manage column widths; report and fix schedule segment overlaps on sheets; export, extract and import Room: Number filter values |
+
+---
+
+### Purge Unused
+
+Tools to remove unused elements from the model. Every tool asks what to remove before
+deleting anything.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Purge%20Unused.panel/Purge.pulldown/Icon.png" width="20" alt=""> | [Purge](purge_unused.md) | Purge unused line styles, fill patterns, line patterns, shared parameters, filters, legends, schedules, view templates and unplaced views |
+
+---
+
+### Warnings
+
+Tools for resolving and locating common Revit warnings on rooms, areas and annotation.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Icon.png" width="20" alt=""> | [Solve Warnings](warnings_solve.md) | Fix room tags outside rooms, duplicate marks, and overlapping area or room separation lines |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Icon.png" width="20" alt=""> | [Highlight Warnings](warnings_highlight.md) | Report area and room separation lines carrying warnings, and colour-highlight them in the active view |
+
+---
+
+### Families
+
+Tools for loading, saving, renaming, swapping and reporting on Revit families and type
+catalogue files.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reload.pushbutton/Icon.png" width="20" alt=""> | [Reload](families_reload.md) | Reload families from a library folder, with match-status filtering |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Rename.pulldown/Icon.png" width="20" alt=""> | [Rename](families_rename.md) | Rename loaded families and types, or rename `.rfa` files in a library folder, from a CSV |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/IO.pulldown/Icon.png" width="20" alt=""> | [IO](families_io.md) | Load families from a folder into the project, or save loaded families out to a folder |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/CatalogueFiles.pulldown/Icon.png" width="20" alt=""> | [CatalogueFiles](families_catalogue_files.md) | Export and clean type catalogue files; strip a family back to a single catalogue placeholder type |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/ForceUpdate.pushbutton/Icon.png" width="20" alt=""> | [Force Update](families_force_update.md) | Force Revit to detect a family as changed when source files have been overwritten |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/ChangeFamilyCategory.pushbutton/Icon.png" width="20" alt=""> | [Change Category](families_change_category.md) | Reassign the open family to a different Revit category, preserving subcategories |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/Reports.pulldown/Icon.png" width="20" alt=""> | [Reports](families_reports.md) | Report on and compare family libraries and projects, via XML part atom exports |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/SwapFamilies.pulldown/Icon.png" width="20" alt=""> | [SwapFamilies](families_swap.md) | Replace family instances with a different type, by CSV directive folder, selection or picking |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Families.panel/AtTheLibrary.pushbutton/Icon.png" width="20" alt=""> | [At The Library](families_at_the_library.md) | Open the AtTheLibrary tool for managing shared type catalogue parameters |
+
+---
+
+### Ceilings
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Ceilings.panel/CeilingsByRooms.pushbutton/Icon.png" width="20" alt=""> | [Ceilings By Room](ceilings_by_rooms.md) | Create a ceiling matching the boundary of each selected room |
+
+---
+
+### Walls
+
+Tools that relate walls and facade openings back to the rooms they bound.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Walls.panel/WallsByRooms.pushbutton/Icon.png" width="20" alt=""> | [Walls By Room](walls_by_rooms.md) | Write the room number onto the walls bounding each selected room |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Walls.panel/FacadeOpeningToRoom.pushbutton/Icon.png" width="20" alt=""> | [Facade Opening To Room](walls_facade_opening.md) | Report external wall and window opening areas per room to CSV |
+
+---
+
+### PushIt
+
+Tools for managing mock rooms — room-like families that carry room data — and the data pushed
+into them.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/PushIt.pushbutton/Icon.png" width="20" alt=""> | [Push It!](pushit_main.md) | Open the PushIt application for loading room data and pushing it into mock rooms |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/GetARoom.splitbutton/Icon.png" width="20" alt=""> | [Get A Room!](pushit_get_a_room.md) | Build mock room families from filled regions; set the family output directory |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/SwapWidthAndDepth.pushbutton/Icon.png" width="20" alt=""> | [Swap Width And Depth](pushit_swap_dimensions.md) | Swap the width and depth values on picked mock rooms and rotate them 90 degrees |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Stats.pulldown/Icon.png" width="20" alt=""> | [Stats](pushit_stats.md) | Report mock room counts by family, creator and owner; flag IDs duplicated across design sets |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/PlaceRevitRooms.pushbutton/Icon.png" width="20" alt=""> | [Place Revit Rooms](pushit_place_revit_rooms.md) | Create native Revit rooms at the locations of mock rooms, read from this model or a link |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/PushIt.panel/Area%20By%20Room.pushbutton/Icon.png" width="20" alt=""> | [Verify Push It Area](pushit_area_by_room.md) | Measure mock rooms with temporary Revit rooms and write the area back onto them |
+
+---
+
+### Export
+
+Tools for exporting sheets, checking exports, and syncing document data.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/PDF_DWG.splitbutton/Icon.png" width="20" alt=""> | [PDF and DWG](export_pdf_dwg.md) | Export sheets to PDF and/or DWG with configurable naming rules and print sets |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/Compare.pushbutton/Icon.png" width="20" alt=""> | [Compare](export_compare.md) | Check the sheets in a Revit schedule against the PDF files in a folder |
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Export.panel/docManager.pulldown/Icon.png" width="20" alt=""> | [docManager](export_docmanager.md) | Sync sheets and revisions from the model to a Document Manager database; configure document numbering |
+
+---
+
+### Data
+
+Scripts for exporting model data to file for reporting and audit purposes.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/Data.panel/Collectors.pulldown/Icon.png" width="20" alt=""> | [Collectors](data_collectors.md) | Export rooms, spaces, sheets, ceilings, floors, doors, levels and placed items to JSON — from the active model and its Revit links |
+
+---
+
+### RoomMate
+
+Integration with a local RoomMate server.
+
+|  | Button Group | Description |
+|:-:|---|---|
+| <img src="Extensions/duHast-2025.extension/duHast.tab/RoomMate.panel/RoomMateRooms.pushbutton/Icon.png" width="20" alt=""> | [Export](roommate.md) | Push room and door data from the model and its links to a local RoomMate server |
 
 ---
 
 ## Getting Started
 
 1. Install [pyRevit](https://github.com/pyrevitlabs/pyRevit) if not already installed.
-2. Copy the extension folder to your pyRevit extensions directory, or add it via pyRevit settings.
+2. Copy the extension folder to your pyRevit extensions directory, or add it via pyRevit
+   settings.
 3. Restart Revit — the **duHast** tab will appear in the ribbon.
-4. Refer to individual button docs (linked above) for prerequisites and configuration steps before first use.
+4. Refer to the individual docs linked above for prerequisites and configuration before first
+   use.
+
+## Before you run a tool
+
+Three things decide whether a button will work at all. Each doc repeats the ones that apply
+to it, but they are worth knowing up front.
+
+**Some tools only run on a family open in the Family Editor.** They exit with "This is not a
+family document." if run from a project: [Change Category](families_change_category.md),
+[Force Update](families_force_update.md) and all three
+[Catalogue Files](families_catalogue_files.md) tools.
+
+**Some tools store their settings in the Revit model** and refuse to start until a Settings
+button has been run on that model: [PDF/DWG Export](export_pdf_dwg.md),
+[docManager](export_docmanager.md) and [Get A Room!](pushit_get_a_room.md). Settings are held
+in an extensible schema, so they travel with the file but do not travel between files.
+
+**Some tools open a .NET window** loaded from the extension's `bin` folder at run time. If
+that folder is missing or incomplete the button fails immediately with a message about the
+bin directory. This applies to [Push It!](pushit_main.md),
+[At The Library](families_at_the_library.md), [Reload](families_reload.md),
+[PDF/DWG Export](export_pdf_dwg.md) and [docManager](export_docmanager.md).
+
+A few tools are also driven by constants edited in the extension's `lib` folder rather than by
+a dialog — see [Facade Opening To Room](walls_facade_opening.md),
+[Ceilings By Room](ceilings_by_rooms.md) and [Reports](families_reports.md).
 
 ## Requirements
 
-- Revit (version compatible with your pyRevit installation)
-- pyRevit (latest stable version recommended)
-- duHast Python library (bundled in the extension)
-- .NET 8 WPF components for tools that open a UI window (PushIt, AtTheLibrary, PDF/DWG Export, DocManager)
+- **Revit 2025 or later** — the extension declares `min_revit_ver: 2025`, with engines
+  configured for 2025 and 2026.
+- pyRevit (latest stable version recommended).
+- duHast Python library — bundled in the extension under `lib/duHast`.
+- The extension's `bin` folder, for the tools that open a .NET window.

--- a/Samples/pyRevit/roommate.md
+++ b/Samples/pyRevit/roommate.md
@@ -1,0 +1,108 @@
+# RoomMate Export
+
+**Panel:** RoomMate | **Button:** Export
+
+<img src="Extensions/duHast-2025.extension/duHast.tab/RoomMate.panel/RoomMateRooms.pushbutton/Icon.png" width="40" alt="button icon">
+
+Exports room and door data from the selected models and pushes it to a **local RoomMate
+server** over HTTP. Nothing is written to disk and nothing in the Revit model is modified.
+
+## Where the data goes
+
+The server is expected on **`http://127.0.0.1:5151`** — the local machine, not a remote
+host. Three endpoints are used:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/settings/projects` | GET | Read the projects registered on the server |
+| `/rooms/stream` | POST | Push rooms and levels |
+| `/doors/stream` | POST | Push doors |
+
+Each push is a **gzip-compressed NDJSON stream** — `Content-Type: application/x-ndjson`,
+`Content-Encoding: gzip` — with the envelope as the first line and one line per room or door
+after it. Large exports are streamed rather than buffered whole.
+
+The RoomMate server must be running before you start; if it cannot be reached the run aborts
+at the project step and nothing is exported.
+
+## What it does
+
+1. **Select the models.** A document picker offers the active document and every loaded
+   Revit link, with multi-select. All selected models are pushed under the same project.
+2. **Select the project.** The list is fetched from the server's registered projects, so it
+   reflects what the server knows, not anything in the Revit file. There is no default and no
+   skip — if the server is unreachable, has no registered projects, or you cancel, the run
+   aborts.
+3. **Select the phase.** Asked once for the whole run, offering only the phase names **common
+   to every selected model**. Each model then resolves that name against its own phases, so
+   the name is what carries across models, not the phase id.
+4. **Per model**, in a cancellable progress bar:
+   - build the envelope (below);
+   - export the rooms and levels that exist in the chosen phase, and push them;
+   - export the doors that exist in the chosen phase, and push them.
+
+**Rooms are pushed before doors, and a failed rooms push stops that model there.** A door
+carries only room *ids*, not room data, so doors pushed against rooms that never landed would
+be meaningless — and a room id is only unique within one model.
+
+## What is sent
+
+**Envelope**, carried by both pushes:
+
+| Field | Source |
+|---|---|
+| `project.id` / `project.name` | The project you picked from the server |
+| `model.id` / `model.name` | The Revit document **Title** |
+| `snapshot.taken_at` | UTC timestamp with microseconds |
+| `phase` | The phase you picked — required; the server refuses a push without it |
+| `model_to_shared` | The model's shared-coordinate transform, as a 2D affine matrix. Optional |
+| `room_boundary` | The model's Area and Volume Computations boundary setting. Rooms push only, optional |
+
+The two optional fields are advisory. If either cannot be read, a message is recorded and the
+push still goes ahead — the server falls back to project-level defaults.
+
+**Rooms push:** duHast room data and building level data for the model, filtered to the
+chosen phase.
+
+**Doors push:** duHast door data, plus per-door placement data read from the Revit API —
+insertion point and the through-wall normal — with `from_room` / `to_room` given as room ids.
+
+## Reading the result
+
+| Outcome | Meaning |
+|---|---|
+| `server accepted` | The push landed and is live |
+| `stored but NOT live` (HTTP 202) | **Rooms only.** The declared phase disagrees with the phase this model was first pushed under, so the payload is quarantined. Nothing reads it until someone activates it on the server |
+| `push failed` | Rejected or unreachable; the message names which |
+
+A 202 is easy to misread as success. If a model does not appear to have updated on the
+server, check for this message first.
+
+For doors there is no 202 — a phase disagreement is **refused outright**, because activating
+it would re-phase the model while its rooms stayed behind.
+
+## Notes on behaviour worth knowing
+
+- **Model identity is the document Title.** Two different files sharing a Title collide into
+  one record on the server, and renaming a file forks its history into a new record. This is
+  a known stopgap — there is no stable GUID available for a plain local file.
+- **One model failing does not abandon the rest.** Each model's export and push runs
+  independently; the run continues and ends red, reporting which model failed and why.
+- **A model with no doors at all is reported as a failure.** That is the server contract, not
+  a bug in the export.
+- Cancelling is honoured after the export and before the post, so a cancel during a long
+  export does not then send the payload anyway.
+- Every message is collected on the run result and printed to the pyRevit output window; read
+  it rather than assuming a completed progress bar means everything landed.
+
+## Requirements
+
+- A RoomMate server running on `127.0.0.1:5151`.
+- The project must already be **onboarded on the server** — the extension cannot create one.
+- The selected models must share at least one phase name, and must have phases at all.
+
+## Not on the ribbon
+
+The library behind this button also provides **rooms-only** and **doors-only** entry points,
+for re-pushing one half without paying for the other's export. Neither has a button in this
+extension; they need wiring up in a `script.py` to be reachable.

--- a/Samples/pyRevit/view_templates_import_export.md
+++ b/Samples/pyRevit/view_templates_import_export.md
@@ -2,57 +2,92 @@
 
 **Panel:** View Templates | **Menu:** Import Export
 
-Tools to transfer view template settings, view filters, and colour schemes between Revit projects using file-based import and export.
+<img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Icon.png" width="40" alt="button icon">
+
+Tools to move view template overrides, view filters and colour fill scheme values between
+projects through files.
+
+Note the file formats differ: view overrides and view filters use **JSON**; colour fill
+scheme values use **CSV**.
 
 ---
 
-## Export View Templates
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Export%20View%20Templates.pushbutton/Icon.png" width="24" alt="Export View Overrides icon"> Export View Overrides
 
-Exports the category override settings from selected view templates in the current project to a file.
+Exports the graphic overrides of selected view templates to a **JSON** file.
 
-- You choose which templates to export.
-- Only graphic overrides (cut, projection, halftone, etc.) per category are exported; template-level settings such as view scale or discipline are not included.
-- The exported file can be imported into another project to apply the same overrides to templates with matching names.
-
----
-
-## Import View Templates
-
-Imports category override settings from an exported file and applies them to view templates in the current project.
-
-- Only templates whose names match entries in the import file are updated.
-- Custom subcategories that exist in the source project but not in the target project are skipped.
-
-**Use when:** You want to standardise graphic overrides across projects that share a common template set.
+- You select which templates to export.
+- Both **category overrides** and **filter overrides** are exported for each template —
+  despite the button name, this is not limited to category settings.
+- Template-level properties such as view scale, detail level or discipline are **not**
+  included.
+- A save dialog asks where to write the `.json` file.
 
 ---
 
-## Export View Filters
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Import%20View%20Templates.pushbutton/Icon.png" width="24" alt="Import View Overrides icon"> Import View Overrides
 
-Exports the definitions of view filters (rules, categories, and graphic overrides) from the current project to a file.
+Applies overrides from an exported JSON file to the templates in the current project.
 
----
+- You select the export file.
+- Templates are matched **by name**. Templates in the file with no name match in the target
+  project are skipped.
+- Custom subcategories that exist in the source project but not in the target are skipped.
 
-## Import View Filters
-
-Imports view filter definitions from an exported file and creates or updates the matching filters in the current project.
-
----
-
-## Export Colour Schemes
-
-Exports colour fill scheme definitions (room colour fills, space colour fills, etc.) from the current project to a file.
+**Use when:** Standardising graphic overrides across projects that share a template set.
 
 ---
 
-## Import Colour Schemes
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Export%20View%20Filters.pushbutton/Icon.png" width="24" alt="Export View Filters icon"> Export View Filters
 
-Imports colour fill scheme definitions from an exported file and applies them to the current project.
+Exports the definitions of **view filters** — rules and categories — to a **JSON** file.
+
+- You select which filters to export from a list of the filters in the project.
+- A save dialog asks where to write the `.json` file.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Import%20View%20Filters.pushbutton/Icon.png" width="24" alt="Import View Filters icon"> Import View Filters
+
+Creates or updates view filters in the current project from an exported JSON file.
+
+- You select the file; the filters it contains are applied to the current document.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Export%20Colour%20Schemes.pushbutton/Icon.png" width="24" alt="Export Colour Fill Scheme Values icon"> Export Colour Fill Scheme Values
+
+Exports the **entries** of one or more colour fill schemes — the values and their colours —
+to a **CSV** file.
+
+- You select which colour fill schemes to export.
+- Schemes with no entries are reported and skipped.
+- A save dialog asks where to write the `.csv` file.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Import%20Export.pulldown/Import%20Colour%20Schemes.pushbutton/Icon.png" width="24" alt="Import Colour Fill Scheme Values icon"> Import Colour Fill Scheme Values
+
+Applies colour fill scheme values from a CSV file to a scheme in the current project. This is
+a four-step wizard, not a single file pick:
+
+1. Select the **CSV file** to read.
+2. Select which **scheme in the file** to import.
+3. Select which **scheme in the current model** to modify.
+4. Select the **update mode**:
+   - **update existing values only** — colours are updated for entries that already exist in
+     the target scheme; nothing is added;
+   - **add new and update existing** — missing entries are created as well.
+
+Because source and target schemes are chosen separately, the two do not need to share a name.
 
 ---
 
 ## Notes
 
-- Import operations match by **name**; ensure template, filter, and scheme names are consistent between source and target projects.
-- Export files are JSON-based and can be committed to version control to track changes to project standards over time.
-- These tools are designed for transferring settings between projects, not for creating templates from scratch.
+- Import matches templates and filters **by name**; keep naming consistent between source and
+  target projects.
+- The JSON exports are text and can be committed to version control to track project
+  standards over time. The colour scheme CSV can be edited in a spreadsheet before importing.
+- These tools transfer settings between existing objects. They do not create templates from
+  scratch.

--- a/Samples/pyRevit/view_templates_modify.md
+++ b/Samples/pyRevit/view_templates_modify.md
@@ -2,53 +2,84 @@
 
 **Panel:** View Templates | **Menu:** Modify
 
-Tools to propagate filter settings and graphic overrides across multiple view templates in the current project in a single operation.
+<img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Icon.png" width="40" alt="button icon">
+
+Tools to propagate filter and category overrides from one view template to many others in the
+current project.
+
+Three of the four tools work **from a source template**. That source selection is the first
+thing they ask for, and it is easy to miss:
+
+> **source template → target templates → what to propagate → apply**
 
 ---
 
-## Apply Filter Overrides
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Apply%20Filter%20Overrides.pushbutton/Icon.png" width="24" alt="Apply Filter Overrides icon"> Apply Filter Overrides
 
-Copies the graphic override settings of selected view filters from a source template to one or more target templates.
+Copies the graphic overrides of selected view filters from a source template to target
+templates.
 
 **Workflow:**
-1. Run the tool.
-2. Select the filters whose overrides you want to propagate.
-3. Select the target view templates to update.
-4. The tool applies the matching filter overrides to every selected target template.
 
-- If a filter does not exist in a target template, it is skipped for that template (existing filters are not removed).
-- Only the graphic overrides (colour, line weight, halftone, etc.) are copied; the filter rules themselves are not changed.
+1. Select the **source view template** — the one whose overrides are correct.
+2. Select the **target view templates** to update.
+3. Select the **filters** whose overrides you want to propagate. Only filters present in the
+   source template are offered.
+4. The overrides are applied.
 
-**Use when:** You have adjusted a filter override in one template and need the same change applied to many other templates.
+- A filter that does not exist in a target template is **skipped** for that template.
+- Only the graphic overrides are copied. The filter rules themselves are untouched.
 
----
-
-## Add And Apply Filter Overrides
-
-An extended version of **Apply Filter Overrides** that also adds the filter to target templates where it does not yet exist, in addition to applying the overrides.
-
-**Use when:** You are rolling out a new filter standard and need to add the filter to all relevant templates as well as setting its overrides.
+**Use when:** You have corrected a filter override in one template and need the same
+correction in many others.
 
 ---
 
-## Apply Graphic Overrides
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Add%20And%20Apply%20Filter%20Overrides.pushbutton/Icon.png" width="24" alt="Add & Apply Filter Overrides icon"> Add & Apply Filter Overrides
 
-Copies category-level graphic overrides (not filter-based) from a source template to one or more target templates.
+Identical to **Apply Filter Overrides**, except that a filter missing from a target template
+is **added** to it before its overrides are applied.
 
-- Useful for propagating changes to cut patterns, projection line weights, or category visibility settings that are defined directly on the template rather than through a filter.
+**Use when:** Rolling out a new filter standard, where the filter needs to reach templates
+that do not yet have it.
 
 ---
 
-## Delete Filters
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Apply%20Graphic%20Overrides.pushbutton/Icon.png" width="24" alt="Apply Graphic Overrides icon"> Apply Graphic Overrides
 
-Removes specified filters from one or more view templates in a single operation.
+Copies **category** overrides and visibility settings from a source template to target
+templates.
 
-- You select which filters to delete and which templates to remove them from.
-- The filter definitions themselves remain in the project; only the assignment to the selected templates is removed.
+**Workflow:**
+
+1. Select the **source view template**.
+2. Select the **target view templates**.
+3. Select the **categories** to propagate.
+4. The settings are applied.
+
+**Use when:** Propagating cut patterns, projection line weights or category visibility that
+are set directly on the template rather than through a filter.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/View%20Templates.panel/Modify.pulldown/Delete%20Filters.pushbutton/Icon.png" width="24" alt="Delete Filters icon"> Delete Filters
+
+Removes filters from view templates. This one has **no source template** — the order is
+reversed:
+
+1. Select the **filters** to remove.
+2. Select the **view templates** to remove them from.
+
+The filter definitions remain in the project; only their assignment to the selected templates
+is removed. Progress is printed per template to the output window.
 
 ---
 
 ## Notes
 
-- All tools act on **view templates** in the current project; they do not modify individual views directly.
-- Test changes on a single target template before applying to all templates in large projects.
+- These tools act on **view templates**, not on individual views. Views using those templates
+  pick the changes up through the template.
+- Test on a single target template before applying across a large project — there is no
+  built-in undo beyond Revit's own.
+- If a tool reports that no filters or categories are available, check the source template
+  actually carries the overrides you expect.

--- a/Samples/pyRevit/views_schedules.md
+++ b/Samples/pyRevit/views_schedules.md
@@ -1,42 +1,61 @@
-# Schedule Tools
+# Schedules
 
 **Panel:** Views | **Menu:** Schedules
+
+<img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Icon.png" width="40" alt="button icon">
 
 Tools for managing Revit schedules — column widths, sheet placement overlaps, and room number filter values.
 
 ---
 
-## Export Column Width
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Export%20Column%20Width.pushbutton/Icon.png" width="24" alt="Export Column Width icon"> Export Column Width
 
-Saves the current column widths of a selected schedule to a file.
+Saves schedule column widths to a **CSV** file.
 
-- You select the schedule to export.
-- Column widths are written to a JSON or CSV file you specify.
-- Use this as a snapshot before changes, or as a template to apply to other schedules.
+- You select the schedules to export — this is a **multi-select** list, not one schedule.
+- A second dialog asks whether to export **all fields** or only **specific fields**.
+- A save dialog asks where to write the `.csv` file.
 
----
-
-## Resize Column Width From Export
-
-Restores column widths to a schedule from a previously saved export file.
-
-- You select the target schedule and the export file.
-- Column widths are applied in the order defined in the file.
-- Columns that exist in the file but not in the schedule are skipped.
-
-**Use when:** A schedule's column widths have been reset (e.g., after upgrading a template) and you need to restore them to a known-good state.
+Use this as a snapshot before changes, or as a source to apply to other schedules.
 
 ---
 
-## Resize Column Width By Name And Value
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Resize%20Column%20Width%20From%20Export.pushbutton/Icon.png" width="24" alt="Resize Column Width From Export icon"> Resize Column Width From Export
 
-Sets schedule column widths by specifying column names and target widths directly, without needing a previously exported file.
+Applies column widths to schedules from a previously saved CSV.
 
-- Useful for applying a standard width to a named set of columns across multiple schedules.
+**Workflow:**
+
+1. Select the **CSV file** first.
+2. Select which **schedules** to update, chosen from those named in the file.
+3. The widths are applied with a progress bar.
+
+- Matching is by **schedule name and field name**, not by column order.
+- Schedules that do not contain a field named in the file are skipped, and listed at the end
+  of the run.
+
+**Use when:** A schedule's column widths have been reset (for example after a template
+upgrade) and you need to restore them to a known-good state.
 
 ---
 
-## Report Schedules Overlaps
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Resize%20Column%20Width%20By%20Name%20And%20Value.pushbutton/Icon.png" width="24" alt="Resize Column Width By Name And Value icon"> Resize Column Width By Name And Value
+
+Sets one column's width across many schedules, without needing an export file.
+
+**Workflow:**
+
+1. Select the **schedules** to modify.
+2. Select the **single field** whose width you want to set.
+3. Enter the width **in millimetres** in the dialog.
+
+Schedules that do not contain that field are skipped and listed at the end of the run.
+
+**Use when:** Applying a standard width to one named column across a set of schedules.
+
+---
+
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Report%20Schedules%20Overlaps.pushbutton/Icon.png" width="24" alt="Report Overlaps icon"> Report Overlaps
 
 Checks selected sheets for schedule segments that are incorrectly positioned and saves a CSV report for each overlap type found.
 
@@ -46,13 +65,17 @@ Checks selected sheets for schedule segments that are incorrectly positioned and
   - Schedule segments overlapping each other on the same sheet.
   - Schedule segments placed outside the title block boundary.
   - Schedule segments overlapping viewports on the sheet.
-- A separate CSV file is written for each overlap type that has findings.
+- A separate CSV file is written for each overlap type that has findings, named after the
+  model:
+  - `<model title>_schedule_segments_overlap.csv`
+  - `<model title>_schedule_overlaps_title_block.csv`
+  - `<model title>_schedule_overlaps_viewports.csv`
 
 **Use when:** You need to audit sheet layouts before issue, or after a template change has caused schedule instances to shift.
 
 ---
 
-## Fix Schedule Segments Overlaps
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Fix%20Schedule%20Segments%20Overlaps.pushbutton/Icon.png" width="24" alt="Fix Segment Overlaps icon"> Fix Segment Overlaps
 
 Automatically resolves overlapping schedule segments on sheets by moving them horizontally until no overlaps remain.
 
@@ -64,7 +87,7 @@ Automatically resolves overlapping schedule segments on sheets by moving them ho
 
 ---
 
-## Export Room Number Filter Value
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Export%20Room%20Number%20Filter%20Value.pushbutton/Icon.png" width="24" alt="Export Room Number Filter Value icon"> Export Room Number Filter Value
 
 Exports the **Room: Number** filter value currently set on each selected schedule to a CSV file.
 
@@ -76,7 +99,7 @@ Exports the **Room: Number** filter value currently set on each selected schedul
 
 ---
 
-## Extract Room Number Filter Value From Schedule Name
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Extract%20Room%20Number%20Filter%20Value%20From%20Schedule%20Name.pushbutton/Icon.png" width="24" alt="Extract Room Number Filter Value icon"> Extract Room Number Filter Value
 
 Reads each selected schedule's name, extracts the room number from it using a prefix you specify, and updates that schedule's **Room: Number** filter value to match.
 
@@ -89,7 +112,7 @@ Reads each selected schedule's name, extracts the room number from it using a pr
 
 ---
 
-## Import Room Number Filter Value
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Views.panel/Schedules.pulldown/Import%20Room%20Number%20Filter%20Value.pushbutton/Icon.png" width="24" alt="Import Room Number Filter Value icon"> Import Room Number Filter Value
 
 Reads a previously exported Room Number filter CSV file and applies the saved filter values back to the matching schedules.
 
@@ -104,6 +127,7 @@ Reads a previously exported Room Number filter CSV file and applies the saved fi
 ## Notes
 
 - Column width tools act on the **schedule view**, not on placed schedule instances on sheets; changes propagate to all sheet instances of the same schedule.
+- Column widths are handled in **millimetres** throughout; the exported CSV carries the same units.
 - Export column widths immediately after finalising a schedule layout to create a restoration point before sharing the template.
 - The overlap report and fix tools operate on **schedule instances on sheets**, not on the schedule view definition.
 - The Room: Number filter tools work with schedules that have a filter on the built-in `Room: Number` field; schedules without that filter are skipped.

--- a/Samples/pyRevit/walls_by_rooms.md
+++ b/Samples/pyRevit/walls_by_rooms.md
@@ -2,6 +2,8 @@
 
 **Panel:** Walls | **Button:** Walls By Room
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Walls.panel/WallsByRooms.pushbutton/Icon.png" width="40" alt="button icon">
+
 Writes the room number of a room into a parameter on the walls bounding that room. Nothing
 is created or moved — this tool only sets parameter values on existing walls.
 

--- a/Samples/pyRevit/walls_facade_opening.md
+++ b/Samples/pyRevit/walls_facade_opening.md
@@ -2,6 +2,8 @@
 
 **Panel:** Walls | **Button:** Facade Opening To Room
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Walls.panel/FacadeOpeningToRoom.pushbutton/Icon.png" width="40" alt="button icon">
+
 Reports the external wall area and the external window opening area for each selected room,
 and writes the result to a CSV file. Nothing is created or modified in the model.
 
@@ -61,8 +63,9 @@ opening family needs an entry in both `OPENING_FAMILY_NAMEs` and the mapper.
 
 ## Notes
 
-- `DEBUG` is set to `True` in the module, so the output window is verbose by default:
-  selected rooms, every opening found, and each wall area calculation are printed.
+- Set `DEBUG = True` in the module for a verbose run — selected rooms, every opening found,
+  and each wall area calculation are then printed to the output window. Useful when the report
+  comes back empty and you need to see which of the three constants is not matching.
 - The wall area is a simple `length x height` rectangle. It is not reduced by the openings,
   and it does not account for parapets, spandrels or sloping soffits.
 - Room area and height are read in project units and written to the CSV as-is; the column

--- a/Samples/pyRevit/warnings_highlight.md
+++ b/Samples/pyRevit/warnings_highlight.md
@@ -2,13 +2,15 @@
 
 **Panel:** Warnings | **Menu:** Highlight Warnings
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Icon.png" width="40" alt="button icon">
+
 Six tools for finding area and room separation lines that carry warnings — two that report
 them model-wide as tables, two that colour them in the active view, and two that clear the
 colouring again.
 
 ---
 
-## Report Area Lines with Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Area%20Lines.pushbutton/Icon.png" width="24" alt="Report Area Lines with Warnings icon"> Report Area Lines with Warnings
 
 Prints a table of every area separation line in the **model** that has a warning attached,
 so you can find them. Nothing is selected, zoomed to or overridden.
@@ -26,7 +28,7 @@ The Area Views column tells you which view to open to reach the lines listed on 
 
 ---
 
-## Report Room Lines with Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Room%20Lines.pushbutton/Icon.png" width="24" alt="Report Room Lines with Warnings icon"> Report Room Lines with Warnings
 
 The same idea for room separation lines, grouped more finely.
 
@@ -41,7 +43,7 @@ Table: *Room separation lines with warnings by design set / option, level and ph
 
 ---
 
-## Highlight Area Lines with Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Highlight%20Area%20Lines.pushbutton/Icon.png" width="24" alt="Highlight Area Lines with Warnings icon"> Highlight Area Lines with Warnings
 
 Overrides the area separation lines that have warnings in the **active view**, setting their
 projection line colour to **red**.
@@ -52,7 +54,7 @@ are considered.
 
 ---
 
-## Highlight Room Lines with Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Highlight%20Room%20Lines.pushbutton/Icon.png" width="24" alt="Highlight Room Lines with Warnings icon"> Highlight Room Lines with Warnings
 
 The room separation line equivalent, also overriding to **red** in the active view.
 
@@ -68,9 +70,9 @@ which is worth reading if fewer lines light up than you expected.
 
 ---
 
-## Remove Highlight from Area Lines without Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Remove%20Highlight%20Area%20Lines.pushbutton/Icon.png" width="24" alt="Remove Highlight from Area Lines without Warnings icon"> Remove Highlight from Area Lines without Warnings
 
-## Remove Highlight from Room Lines without Warnings
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Highlight%20Warnings.pulldown/Remove%20Highlight%20Room%20Lines.pushbutton/Icon.png" width="24" alt="Remove Highlight from Room Lines without Warnings icon"> Remove Highlight from Room Lines without Warnings
 
 These do **not** clear every highlight. They remove the override from the lines that **no
 longer have warnings**, deliberately leaving the still-warning lines coloured.

--- a/Samples/pyRevit/warnings_solve.md
+++ b/Samples/pyRevit/warnings_solve.md
@@ -2,6 +2,8 @@
 
 **Panel:** Warnings | **Menu:** Solve Warnings
 
+<img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Icon.png" width="40" alt="button icon">
+
 Automated fixes for four common Revit warning types. Each tool collects the warnings of its
 type from the **whole document**, then works through them with a cancellable progress bar.
 None of them is view-scoped, and none requires a selection.
@@ -10,7 +12,7 @@ If the model holds no warnings of the relevant type, the tool reports so and exi
 
 ---
 
-## Room tags outside of room
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Room%20Tags%20Outside%20Room.pushbutton/Icon.png" width="24" alt="Room tags outside of room icon"> Room tags outside of room
 
 Moves room tags that Revit reports as sitting outside their room back onto the room.
 
@@ -25,7 +27,7 @@ documentation relies on tag leaders, review the affected tags afterwards.
 
 ---
 
-## Duplicate Marks
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Duplicate%20Marks.pushbutton/Icon.png" width="24" alt="Duplicate Marks icon"> Duplicate Marks
 
 Resolves **Duplicate Mark** warnings by clearing the Mark parameter.
 
@@ -39,7 +41,7 @@ relied upon.
 
 ---
 
-## Area Lines Overlap Long / Room Lines Overlap Long
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Area%20Separation%20Lines%20Long.pushbutton/Icon.png" width="24" alt="Area Lines Overlap Long icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Room%20Separation%20Lines%20Long.pushbutton/Icon.png" width="24" alt="Room Lines Overlap Long icon"> Area Lines Overlap Long / Room Lines Overlap Long
 
 Resolves overlapping area or room separation line warnings by **lengthening**:
 
@@ -50,7 +52,7 @@ The result is a single continuous line.
 
 ---
 
-## Area Lines Overlap Short / Room Lines Overlap Short
+## <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Area%20Separation%20Lines%20Short.pushbutton/Icon.png" width="24" alt="Area Lines Overlap Short icon"> <img src="Extensions/duHast-2025.extension/duHast.tab/Warnings.panel/Solve%20Warnings.pulldown/Room%20Separation%20Lines%20Short.pushbutton/Icon.png" width="24" alt="Room Lines Overlap Short icon"> Area Lines Overlap Short / Room Lines Overlap Short
 
 Resolves the same warnings by **shortening**:
 


### PR DESCRIPTION
Reviewed the 32 markdown files in `Samples/pyRevit/` against the extension they describe. They read as though written from folder names and button labels rather than from the scripts: about a third documented a **different tool** than the one that runs. Reviewing them also turned up several buttons that cannot work.

Two commits, deliberately separate — the code changes alter behaviour in Revit, the docs don't.

## `0caf3f02` Fix broken pyRevit buttons and stale bundle layouts

**Buttons that could not work:**

- **Export File** (catalogue) — the module-level `def export_catalogue_file` shadowed the duHast import of the same name, so the call recursed into itself with the library's kwargs and raised `TypeError`. Import is now aliased.
- **Reload** — `print("...").format(...)` applied `.format` to the return value of `print`. Harmless under IronPython 2.7, fatal under a CPython 3 engine, and `extension.json` declares engines for 2025 and 2026.
- **Reload** — the UI's *Import All Types On Reload* radio button was never read, so `reload_family` always ran with its `delete_new_types` default and the setting silently did nothing. `ReloadSelection.LoadAllFamilyTypesOnReload` is now passed through.

**Bundle layouts** (these were producing the stray dividers in the ribbon):

- `duHast.tab` listed a `Colour Fill Schemes` panel with no folder on disk.
- `View Templates > Modify` listed `Add And Apply Filter Overrides Views`, which matched nothing, leaving a dangling separator at the foot of the dropdown. The button itself was already listed correctly.

**Also:** `bulk_load.get_families` never populated `file_names`, so its documented duplicate filter was a no-op; a stray `print("hello world")` and a left-on `DEBUG = True`; and several copy-pasted docstrings (ChangeFamilyCategory carried ForceUpdate's; the ceilings and walls entry points both claimed to compare library reports).

## `68549f59` Rewrite pyRevit extension docs from the code

**Rewritten — these documented the wrong behaviour:**

| Doc | Was documented as | Actually does |
|---|---|---|
| `walls_by_rooms` | Generates walls | Stamps the room number onto bounding walls |
| `walls_facade_opening` | Creates rooms | CSV report of external wall and window areas |
| `export_compare` | Two export folders, file hashes | Revit schedule vs PDFs in a folder |
| `families_catalogue_files` | Sets a pre-selected type | **Deletes every type in the family** |
| `families_change_category` | Works from the project | Family Editor only |
| `warnings_solve` | Long/Short = search radius | Lengthen-and-delete vs trim-the-overlap |
| `warnings_highlight` | Select and zoom | Model-wide report tables |
| `pushit_stats`, `pushit_area_by_room`, `pushit_get_a_room` | — | All three described outcomes the code does not produce |

**Corrected on detail** — mostly the dialog sequence, and hard-coded values that decide whether a tool does anything at all: `cloud_guids`, `data_collectors`, `ceilings_by_rooms`, `purge_unused`, `grids`, `levels`, `view_templates_*`, `views_schedules`, `families_{reload,io,reports,swap,rename,force_update}`, `export_{docmanager,pdf_dwg}`, `pushit_{swap_dimensions,place_revit_rooms}`.

**New:** `roommate.md` (the panel had no docs at all — it posts room and door data to a local server as gzip NDJSON) and `about.md`.

**readme:** rebuilt in true ribbon order from the bundle layouts, with the labels Revit displays; added a *Before you run a tool* section covering family-editor-only tools, model-schema settings tools, and tools needing the `bin` folder. Every doc now carries its button icons.

## Before merging

The code fixes are **verified statically only** — AST parse and call-site inspection. I had no way to run them in Revit. The reloader's type-import mode and the catalogue-file export both want a run against a real model.

## Left deliberately

- **Copy And Rename Families in Folder** is an unimplemented feature, not an unwired button — the library function stops part way through, so connecting the button achieves nothing. Documented as unavailable.
**Resolved during review:** `ceilings_create.get_ceiling_type_from_room` reads the ceiling type mark via `BuiltInParameter.WINDOW_TYPE_ID`. This looked like a copy-paste, but it is correct — `WINDOW_TYPE_ID` is the built-in behind the **Type Mark** parameter across many categories, not just windows, and is what a ceiling type's Type Mark resolves to (confirmed against a ceiling type in RevitLookup: Type Mark → `WINDOW_TYPE_ID`, id `-1001405`). `ALL_MODEL_TYPE_MARK` would have matched nothing. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


