### PR TITLE
Stop in place ceilings and unmeasurable floors vanishing from the export

### DIFF
--- a/src/duHast/Revit/Ceilings/Export/to_data_ceiling.py
+++ b/src/duHast/Revit/Ceilings/Export/to_data_ceiling.py
@@ -61,7 +61,9 @@ def populate_data_ceiling_object(doc, revit_ceiling):
     :param revit_ceiling: A revit ceiling instance.
     :type revit_ceiling: Autodesk.Revit.DB.Ceiling
 
-    :return: A data ceiling object instance.
+    :return: A data ceiling object instance. Always an object, never None: a
+        ceiling whose geometry could not be measured comes back with an empty
+        `polygon` and every other field populated. See the body for why.
     :rtype: :class:`.DataCeiling`
     """
 
@@ -69,7 +71,23 @@ def populate_data_ceiling_object(doc, revit_ceiling):
     data_c = dCeiling.DataCeiling()
     # get ceiling geometry (boundary points)
     revit_geometry_point_groups = rSolid.get_2d_points_from_solid(revit_ceiling)
-    # revitGeometryPointGroups = Geometry.Get2DPointsFromRevitCeiling(revitCeiling)
+
+    # An unmeasurable ceiling is returned with an EMPTY polygon rather than as
+    # None, and this used to be the other way round.
+    #
+    # A ceiling this function cannot measure still has a perfectly good id,
+    # level, phase, design option and both property maps. Answering None threw
+    # all of that away and, worse, left the caller unable to tell "no such
+    # ceiling" from "a ceiling nobody could measure" - the two look identical
+    # once the element is missing from the export, and they send a reader to
+    # opposite places. One is a model that has no ceiling there; the other is a
+    # defect in this pipeline.
+    #
+    # Same lesson as the uninitialized BoundingBoxXYZ that used to reach
+    # consumers as plausible-looking geometry: a value nothing can distinguish
+    # from a real one is worse than an explicit empty. The consumer decides what
+    # an empty polygon means, exactly as it already does for a space, which is
+    # pushed with an empty outline when its bounding elements live in a link.
     if len(revit_geometry_point_groups) > 0:
         ceiling_point_groups_as_doubles = []
         for all_ceiling_point_groups in revit_geometry_point_groups:
@@ -79,42 +97,46 @@ def populate_data_ceiling_object(doc, revit_ceiling):
             ceiling_point_groups_as_doubles.append(data_geo_converted)
         data_c.polygon = ceiling_point_groups_as_doubles
 
-        # get design set data
-        design_set = get_design_set_data(doc=doc, element=revit_ceiling)
-        data_c.design_set_and_option = design_set
+    # get design set data
+    design_set = get_design_set_data(doc=doc, element=revit_ceiling)
+    data_c.design_set_and_option = design_set
 
-        # get type properties
-        type_props = get_type_properties(doc=doc, element=revit_ceiling)
-        data_c.type_properties = type_props
+    # get type properties
+    type_props = get_type_properties(doc=doc, element=revit_ceiling)
+    data_c.type_properties = type_props
 
-        # get instance properties
-        instance_props = get_instance_properties(revit_ceiling)
-        data_c.instance_properties = instance_props
+    # get instance properties
+    instance_props = get_instance_properties(revit_ceiling)
+    data_c.instance_properties = instance_props
 
-        # get level properties
-        level = get_level_data(
-            doc=doc,
-            element=revit_ceiling,
-            built_in_parameter_def=BuiltInParameter.CEILING_HEIGHTABOVELEVEL_PARAM,
-        )
-        data_c.level = level
+    # get level properties
+    level = get_level_data(
+        doc=doc,
+        element=revit_ceiling,
+        built_in_parameter_def=BuiltInParameter.CEILING_HEIGHTABOVELEVEL_PARAM,
+    )
+    data_c.level = level
 
-        # get the model name
-        model = get_model_data(doc=doc)
-        data_c.revit_model = model
+    # get the model name
+    model = get_model_data(doc=doc)
+    data_c.revit_model = model
 
-        # get phasing information
-        phase = get_phasing_data(doc=doc, element=revit_ceiling)
-        data_c.phasing = phase
+    # get phasing information
+    phase = get_phasing_data(doc=doc, element=revit_ceiling)
+    data_c.phasing = phase
 
-        return data_c
-    else:
-        return None
+    return data_c
 
 
 def get_all_ceiling_data(doc):
     """
     Gets a list of ceiling data objects for each ceiling element in the model.
+
+    One entry per ceiling in the model, INCLUDING any whose geometry could not
+    be measured - those carry an empty `polygon`. The count of this list can
+    therefore be compared against the collector's count to find a pipeline
+    problem, which was impossible while unmeasurable ceilings were silently
+    dropped.
 
     :param doc: Current Revit model document.
     :type doc: Autodesk.Revit.DB.Document
@@ -126,6 +148,10 @@ def get_all_ceiling_data(doc):
     ceilings = rCeiling.get_all_ceiling_instances_in_model_by_category(doc)
     for ceiling in ceilings:
         cd = populate_data_ceiling_object(doc, ceiling)
+        # `populate_data_ceiling_object` no longer answers None. The guard stays
+        # as a cheap backstop rather than being deleted: this loop is the only
+        # thing between a future regression there and a list with a None in it,
+        # which would fail much further downstream than here.
         if cd is not None:
             all_ceiling_data.append(cd)
     return all_ceiling_data

--- a/src/duHast/Revit/Common/Geometry/solids.py
+++ b/src/duHast/Revit/Common/Geometry/solids.py
@@ -34,11 +34,56 @@ from duHast.Revit.Common.Geometry.geometry import merge_bounding_box_xyz, get_fa
 from duHast.Data.Objects.Collectors.Properties.Geometry import geometry_polygon_2 as dGeometryPoly
 
 
+def _solids_from_geometry_instances(geometry_element, solids=None):
+    """
+    Collects solids out of the GeometryInstances in a geometry element.
+
+    An IN PLACE family is a FamilyInstance, and its geometry element holds a
+    GeometryInstance rather than solids sitting at the top level - so a walk that
+    only looks at the top level finds nothing at all for one. That is why
+    `get_2d_points_from_solid` used to carry "Does not work with in place
+    elements" in its docstring, and a todo in its body.
+
+    GetInstanceGeometry and deliberately not GetSymbolGeometry: the symbol
+    version is the family as authored, before its host cuts it, and measures
+    larger than the object actually in the model. Same reasoning as
+    `get_solids_from_geometry` below, which this deliberately does NOT reuse -
+    see the caller for why.
+
+    :param geometry_element: The geometry element to walk.
+    :type geometry_element: Autodesk.Revit.DB.GeometryElement
+    :param solids: Accumulator, used when recursing.
+    :type solids: list
+
+    :return: A list of solids.
+    :rtype: list of Autodesk.Revit.DB.Solid
+    """
+
+    if solids is None:
+        solids = []
+
+    for geometry_obj in geometry_element:
+        if geometry_obj is None:
+            continue
+        if type(geometry_obj) is Solid:
+            solids.append(geometry_obj)
+            continue
+        get_instance_geometry = getattr(geometry_obj, "GetInstanceGeometry", None)
+        if get_instance_geometry is None:
+            continue  # a curve, a line, a mesh - nothing with a volume
+        instance_geometry = get_instance_geometry()
+        if instance_geometry is not None:
+            _solids_from_geometry_instances(instance_geometry, solids)
+
+    return solids
+
+
 def get_2d_points_from_solid(element):
     """
     Returns a list of lists of data geometry instances representing the flattened (2D geometry) of the Element
     List of Lists because an element can be made up of multiple solids. Each nested list represents one element solid.
-    Does not work with in place elements.
+
+    Handles in place elements, see `_solids_from_geometry_instances`.
 
     :param element: A revit element instance.
     :type element: Autodesk.Revit.DB.Element
@@ -53,10 +98,32 @@ def get_2d_points_from_solid(element):
     fr1_geom = element.get_Geometry(opt)
     solids = []
     # check geometry for Solid elements
-    # todo check for FamilyInstance geometry ( in place families!)
     for item in fr1_geom:
         if type(item) is Solid:
             solids.append(item)
+
+    # Nothing at the top level: this is an in place family, whose solids sit
+    # inside a GeometryInstance. Descending is what stops one being dropped
+    # silently by every caller of this function - a ceiling that produces no
+    # points is dropped from the export entirely, and downstream it is then
+    # indistinguishable from one nobody modelled.
+    #
+    # ONLY when the top level found nothing, which makes this change provably
+    # inert for every element that already works. Always merging both walks
+    # would alter the solid list for elements exporting fine today, and this
+    # function feeds ceilings AND floors, so a regression here would land in two
+    # entities at once with nothing to catch it. The two populations are
+    # disjoint anyway: a system-family ceiling has top-level solids and no
+    # instance geometry, an in place one has only instance geometry.
+    #
+    # `get_solids_from_geometry` below does the same recursion and is NOT reused
+    # here on purpose. It also filters on `Volume > 0` and on
+    # `Id == InvalidElementId`, and it has only ever been called on family
+    # instances - neither guard has been tested against a plain Ceiling or
+    # Floor, so reusing it would put an unmeasured filter in front of the
+    # population that currently works.
+    if not solids:
+        solids = _solids_from_geometry_instances(fr1_geom)
 
     # process solids to points
     # in place families may have more then one solid

--- a/src/duHast/Revit/Floors/Export/to_data_floor.py
+++ b/src/duHast/Revit/Floors/Export/to_data_floor.py
@@ -60,7 +60,9 @@ def populate_data_floor_object(doc, revit_floor):
     :param revit_floor: A revit floor instance.
     :type revit_floor: Autodesk.Revit.DB.Floor
 
-    :return: A data floor object instance.
+    :return: A data floor object instance. Always an object, never None: a floor
+        whose geometry could not be measured comes back with an empty `polygon`
+        and every other field populated. See the body for why.
     :rtype: :class:`.DataFloor`
     """
 
@@ -68,6 +70,14 @@ def populate_data_floor_object(doc, revit_floor):
     data_f = dFloor.DataFloor()
     # get floor geometry (boundary points)
     revit_geometry_point_groups = rSolid.get_2d_points_from_solid(revit_floor)
+
+    # An unmeasurable floor is returned with an EMPTY polygon rather than as
+    # None, and this used to be the other way round. Same change and same
+    # reasoning as `to_data_ceiling.populate_data_ceiling_object`, which carries
+    # the full argument: the element still has a good id, level, phase, design
+    # option and both property maps, and dropping it leaves the caller unable to
+    # tell "no such floor" from "a floor nobody could measure" - a model fact and
+    # a pipeline defect, which send a reader to opposite places.
     if len(revit_geometry_point_groups) > 0:
         floor_point_groups_as_doubles = []
         for all_floor_point_groups in revit_geometry_point_groups:
@@ -77,42 +87,46 @@ def populate_data_floor_object(doc, revit_floor):
             floor_point_groups_as_doubles.append(data_geo_converted)
         data_f.polygon = floor_point_groups_as_doubles
 
-        # get design set data
-        design_set = get_design_set_data(doc=doc, element=revit_floor)
-        data_f.design_set_and_option = design_set
+    # get design set data
+    design_set = get_design_set_data(doc=doc, element=revit_floor)
+    data_f.design_set_and_option = design_set
 
-        # get type properties
-        type_props = get_type_properties(doc=doc, element=revit_floor)
-        data_f.type_properties = type_props
+    # get type properties
+    type_props = get_type_properties(doc=doc, element=revit_floor)
+    data_f.type_properties = type_props
 
-        # get instance properties
-        instance_props = get_instance_properties(revit_floor)
-        data_f.instance_properties = instance_props
+    # get instance properties
+    instance_props = get_instance_properties(revit_floor)
+    data_f.instance_properties = instance_props
 
-        # get level properties
-        level = get_level_data(
-            doc=doc,
-            element=revit_floor,
-            built_in_parameter_def=BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM,
-        )
-        data_f.level = level
+    # get level properties
+    level = get_level_data(
+        doc=doc,
+        element=revit_floor,
+        built_in_parameter_def=BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM,
+    )
+    data_f.level = level
 
-        # get the model name
-        model = get_model_data(doc=doc)
-        data_f.revit_model = model
+    # get the model name
+    model = get_model_data(doc=doc)
+    data_f.revit_model = model
 
-        # get phasing information
-        phase = get_phasing_data(doc=doc, element=revit_floor)
-        data_f.phasing = phase
+    # get phasing information
+    phase = get_phasing_data(doc=doc, element=revit_floor)
+    data_f.phasing = phase
 
-        return data_f
-    else:
-        return None
+    return data_f
 
 
 def get_all_floor_data(doc):
     """
     Gets a list of floor data objects for each floor element in the model.
+
+    One entry per floor in the model, INCLUDING any whose geometry could not be
+    measured - those carry an empty `polygon`. The count of this list can
+    therefore be compared against the collector's count to find a pipeline
+    problem, which was impossible while unmeasurable floors were silently
+    dropped.
 
     :param doc: Current Revit model document.
     :type doc: Autodesk.Revit.DB.Document
@@ -124,6 +138,10 @@ def get_all_floor_data(doc):
     floors = rFloor.get_all_floor_instances_in_model_by_category(doc)
     for floor in floors:
         fd = populate_data_floor_object(doc, floor)
+        # `populate_data_floor_object` no longer answers None. The guard stays as
+        # a cheap backstop rather than being deleted: this loop is the only thing
+        # between a future regression there and a list with a None in it, which
+        # would fail much further downstream than here.
         if fd is not None:
             all_floor_data.append(fd)
     return all_floor_data


### PR DESCRIPTION
A ceiling modelled as an in place family is absent from `get_all_ceiling_data`, and nothing downstream can tell that from a model with no ceiling there. Two defects, one visible symptom.

Found while designing a ceilings entity for RoomMate, where "how many ceilings get dropped" is a kill condition rather than a detail: a dropped ceiling and an unmodelled one are indistinguishable once the element is missing from the export.

## 1. `stop in place ceilings vanishing from the export`

**The geometry blind spot.** `get_2d_points_from_solid` only ever collected solids sitting at the **top level** of the geometry element. An in place family is a `FamilyInstance` and its geometry element holds a `GeometryInstance`, so the walk found nothing at all for one — which the docstring admitted ("Does not work with in place elements") and the body carried a `todo` for. `_solids_from_geometry_instances` now descends into `GetInstanceGeometry`.

The fallback runs **only when the top level found nothing**, which makes the change provably inert for every element that already exports. Always merging both walks would alter the solid list for elements that are fine today, and this function feeds ceilings *and* floors, so a regression would land in two entities at once with nothing to catch it. The two populations are disjoint anyway: a system family ceiling has top level solids and no instance geometry, an in place one has only instance geometry.

`get_solids_from_geometry` does the same recursion and is deliberately **not** reused. It additionally filters on `Volume > 0` and on `Id == InvalidElementId`, and it has only ever been called on family instances — neither guard has been tested against a plain `Ceiling` or `Floor`, so reusing it would put an unmeasured filter in front of the population that currently works.

**The silent drop.** `populate_data_ceiling_object` returned `None` for a ceiling it could not measure. That threw away a good id, level, phase, design option and both property maps, and left the caller unable to separate "no such ceiling" from "a ceiling nobody could measure" — a model fact and a pipeline defect. It now always returns the object, with an empty `polygon`, exactly as a space is exported with an empty outline when its bounding elements live in a link.

## 2. `export an unmeasurable floor instead of dropping it`

The same `None` change for the entity that shares the geometry walk. Its own commit rather than folded into the first, so the ceiling result stays readable if either needs backing out.

## Downstream

Additive, checked rather than assumed. `get_shapely_polygons_from_data_instance` iterates `data_instance.polygon` and returns an empty list for an object with none, so `process_ceilings_to_rooms` and `process_floors_to_rooms` report the matches they did before.

What is gained: the count of `get_all_ceiling_data` / `get_all_floor_data` can now be compared against the collector's count to find a pipeline problem, which was impossible while unmeasurable elements were silently dropped.

## Verification

The real text of `_solids_from_geometry_instances` was run against stubbed geometry — top level solids, curves only, one instance, nested instances, mixed, `None` entries, an instance returning `None`, empty input, and no leak between calls through the mutable default. All pass.

That is control flow only. **Nothing here is verified against Revit**, which needs a document with an in place ceiling in it. The drop rate is what `scripts/probe_ceilings_export.py` in the RoomMate repo was written to measure, and this branch should be confirmed against a real document before it is relied on.

## Note for anyone testing this

`Samples/pyRevit/Extensions/duHast-2025.extension/lib/` is gitignored, so the deployed copy of these three files does **not** travel with the branch. Redeploy `lib/` before running the extension against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
